### PR TITLE
increase api call timeout and add exception logger

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -3,10 +3,32 @@
 
 See README https://github.com/logandk/serverless-wsgi
 """
+import logging
 import serverless_wsgi
 
 from sequence_run_manager.wsgi import application
 
+logger = logging.getLogger(__name__)
+
 
 def handler(event, context):
-    return serverless_wsgi.handle_request(application, event, context)
+    """
+    Lambda handler with exception logging.
+
+    Logs all exceptions with remaining time for monitoring in CloudWatch.
+    """
+    try:
+        return serverless_wsgi.handle_request(application, event, context)
+    except Exception as e:
+        # Log all exceptions with remaining time and context info
+        remaining_ms = context.get_remaining_time_in_millis()
+        remaining_seconds = remaining_ms / 1000.0
+
+        logger.error(
+            f"Lambda exception: {remaining_seconds:.2f}s remaining. "
+            f"Request ID: {context.aws_request_id}, "
+            f"Function: {context.function_name}, "
+            f"Log stream: {context.log_stream_name}, "
+            f"Error type: {type(e).__name__}, Error: {str(e)}"
+        )
+        raise

--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -163,7 +163,7 @@ export class SequenceRunManagerStack extends Stack {
     const apiFn: PythonFunction = this.createPythonFunction('Api', {
       index: 'api.py',
       handler: 'handler',
-      timeout: Duration.seconds(28),
+      timeout: Duration.minutes(1),
     });
 
     const srmApi = new OrcaBusApiGateway(this, 'ApiGateway', props.apiGatewayCognitoProps);


### PR DESCRIPTION
1. increase api call timeout to 1 min (~ 2 times before)
2. add exception logger when call error. Cloud watch log will be more informative when error 

Related to https://github.com/OrcaBus/service-sequence-run-manager/issues/25