### PR TITLE
add supoort for ready state

### DIFF
--- a/app/sequence_run_manager/models/sequence.py
+++ b/app/sequence_run_manager/models/sequence.py
@@ -51,7 +51,7 @@ class SequenceStatus(models.TextChoices):
         :return:
         """
         value = str(value).lower()
-        if value in ["uploading", "running", "new"]:
+        if value in ["uploading", "running", "new", "ready"]:
             return cls.STARTED
         elif value in ["complete", "analyzing", "pendinganalysis"]:
             return cls.SUCCEEDED


### PR DESCRIPTION
Fix for 
<img width="908" height="281" alt="image" src="https://github.com/user-attachments/assets/8322e29e-c9b4-4439-b45a-1057304c74bb" />

The new NovaSeq X instrument will emit new bssh event state "Ready"
<img width="163" height="333" alt="image" src="https://github.com/user-attachments/assets/593cf784-1736-438f-a680-2a6f8354233b" />
