### PR TITLE
increase api lambda memory limit

### DIFF
--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -170,6 +170,7 @@ export class SequenceRunManagerStack extends Stack {
       index: 'api.py',
       handler: 'handler',
       timeout: Duration.minutes(1),
+      memorySize: 1024,
     });
 
     const srmApi = new OrcaBusApiGateway(this, 'ApiGateway', props.apiGatewayCognitoProps);


### PR DESCRIPTION
 related to https://github.com/OrcaBus/service-sequence-run-manager/issues/25

increase api lambda memory limit