### PR TITLE
refactor-stats-api

### DIFF
--- a/app/sequence_run_manager/serializers/sequence_run.py
+++ b/app/sequence_run_manager/serializers/sequence_run.py
@@ -46,12 +46,17 @@ class SequenceRunGroupByInstrumentRunIdSerializer(serializers.Serializer):
     instrument_run_id = serializers.CharField(help_text="The instrument run ID")
     start_time = serializers.DateTimeField(help_text="Earliest start time of sequences in this group")
     end_time = serializers.DateTimeField(help_text="Latest end time of sequences in this group")
+    status = serializers.CharField(
+        help_text="Group status: latest sequence in the group by start_time (then orcabus_id)",
+        required=False,
+        allow_null=True,
+    )
     count = serializers.IntegerField(help_text="Number of sequences in this group")
     items = SequenceRunMinSerializer(many=True)
 
     class Meta(OrcabusIdSerializerMetaMixin):
         model = Sequence
-        fields = ["instrument_run_id", "start_time", "end_time", "count", "items"]
+        fields = ["instrument_run_id", "start_time", "end_time", "status", "count", "items"]
 
     def get_schema(self):
         """

--- a/app/sequence_run_manager/serializers/sequence_run.py
+++ b/app/sequence_run_manager/serializers/sequence_run.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
+from rest_framework.settings import api_settings
 
-from sequence_run_manager.models import Sequence
+from sequence_run_manager.models import Sequence, SequenceStatus
 from sequence_run_manager.serializers.base import SerializersBase, OptionalFieldsMixin, OrcabusIdSerializerMetaMixin
 
 
@@ -9,9 +10,96 @@ class SequenceBaseSerializer(SerializersBase):
 
 
 class SequenceRunListParamSerializer(OptionalFieldsMixin, SequenceBaseSerializer):
+    """
+    Model field filters for list / stats / grouped list (exact ``__iexact`` match per query key;
+    see ``Sequence.objects.get_by_keyword`` / ``build_keyword_params``).
+    """
+
     class Meta(OrcabusIdSerializerMetaMixin):
         model = Sequence
-        fields = "__all__"
+        fields = [
+            "orcabus_id",
+            "sequence_run_id",
+            "instrument_run_id",
+            "sequence_run_name",
+            "experiment_name",
+            "sample_sheet_name",
+            "v1pre3_id",
+            "ica_project_id",
+            "api_url",
+            "run_volume_name",
+            "run_folder_path",
+            "run_data_uri",
+            "reagent_barcode",
+            "flowcell_barcode",
+        ]
+
+
+class SequenceRunListQueryParamSerializer(SequenceRunListParamSerializer):
+    """
+    Full query parameter schema for sequence run list, ``list_by_instrument_run_id``, and stats
+    endpoints (OpenAPI / drf-spectacular).
+
+    Includes model field filters from ``SequenceRunListParamSerializer`` plus the filters
+    implemented in ``filtered_sequence_runs_queryset`` and ordering in ``SequenceRunViewSet``.
+
+    Search and sort use the DRF query keys from ``REST_FRAMEWORK`` (``SEARCH_PARAM``,
+    ``ORDERING_PARAM``), not duplicate aliases.
+    """
+
+    start_time = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="ISO 8601 datetime; lower bound on ``Sequence.start_time`` (use with end_time).",
+    )
+    end_time = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="ISO 8601 datetime; upper bound on ``Sequence.start_time`` (use with start_time).",
+    )
+    library_id = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text="Only sequences linked to this library id (via library association).",
+    )
+    status = serializers.ChoiceField(
+        choices=SequenceStatus.choices,
+        required=False,
+        allow_blank=True,
+        help_text=(
+            "Filter by ``Sequence.status`` on each row (list and per-sequence stats). "
+            "For ``list_by_instrument_run_id`` and instrument-run stats, filters by **group** "
+            "status (latest sequence in the group by start_time, then orcabus_id)."
+        ),
+    )
+
+    # Field names must match REST_FRAMEWORK query keys (defaults: search, ordering).
+    locals()[api_settings.SEARCH_PARAM] = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text=(
+            "Case-insensitive substring search on orcabus_id, instrument_run_id, sequence_run_id, "
+            "sequence_run_name, experiment_name, and sample_sheet_name."
+        ),
+    )
+    locals()[api_settings.ORDERING_PARAM] = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        help_text=(
+            "Sort field; must be one of: orcabus_id, instrument_run_id, start_time, end_time, status "
+            "(prefix with '-' for descending)."
+        ),
+    )
+
+    class Meta(SequenceRunListParamSerializer.Meta):
+        fields = SequenceRunListParamSerializer.Meta.fields + [
+            "start_time",
+            "end_time",
+            "library_id",
+            "status",
+            api_settings.SEARCH_PARAM,
+            api_settings.ORDERING_PARAM,
+        ]
 
 class SequenceRunMinSerializer(SequenceBaseSerializer):
     class Meta(OrcabusIdSerializerMetaMixin):

--- a/app/sequence_run_manager/tests/test_viewsets.py
+++ b/app/sequence_run_manager/tests/test_viewsets.py
@@ -43,6 +43,12 @@ class SequenceViewSetTestCase(TestCase):
     sequence_run_endpoint = f"/{api_base}sequence_run"
     sequence_endpoint = f"/{api_base}sequence"
     sample_sheet_endpoint = f"/{api_base}sample_sheet"
+    stats_sequence_run_status_counts_endpoint = (
+        f"/{api_base}stats/sequence_run_status_counts"
+    )
+    stats_instrument_run_status_counts_endpoint = (
+        f"/{api_base}stats/instrument_run_status_counts"
+    )
 
     def setUp(self):
         # Use DRF's APIClient for better compatibility with DRF viewsets
@@ -103,6 +109,112 @@ class SequenceViewSetTestCase(TestCase):
         Comment.objects.all().delete()
         State.objects.all().delete()
         LibraryAssociation.objects.all().delete()
+
+    def test_list_status_filters_sequence_row_group_status_filters_latest_in_group(self):
+        """
+        ``GET /sequence_run/?status=`` filters ``Sequence.status`` per row.
+        ``list_by_instrument_run_id`` uses ``status`` against the group's latest-by-start_time status.
+        """
+        instrument_run_id = "190101_A01052_0001_BH5LY7ACGT"
+        Sequence.objects.create(
+            instrument_run_id=instrument_run_id,
+            run_volume_name="gds_name",
+            run_folder_path="/to/gds/folder/path",
+            run_data_uri="gds://gds_name/to/gds/folder/path",
+            status=SequenceStatus.STARTED,
+            start_time=now() - timedelta(days=1),
+            sample_sheet_name="SampleSheet.csv",
+            sequence_run_id="r.OLDER",
+            sequence_run_name=instrument_run_id,
+            api_url="https://bssh.dev/api/v1/runs/r.OLDER",
+            v1pre3_id="1234567890",
+            ica_project_id="12345678-53ba-47a5-854d-e6b53101adb7",
+            experiment_name="ExperimentName",
+        )
+
+        list_started = self.client.get(f"{self.sequence_run_endpoint}/?status=STARTED")
+        self.assertEqual(list_started.status_code, 200)
+        self.assertEqual(len(list_started.data["results"]), 1)
+        self.assertEqual(list_started.data["results"][0]["sequence_run_id"], "r.OLDER")
+
+        grouped = self.client.get(
+            f"{self.sequence_run_endpoint}/list_by_instrument_run_id/?status=STARTED"
+        )
+        self.assertEqual(grouped.status_code, 200)
+        self.assertEqual(len(grouped.data.get("results", [])), 0)
+
+        grouped_succ = self.client.get(
+            f"{self.sequence_run_endpoint}/list_by_instrument_run_id/?status=SUCCEEDED"
+        )
+        self.assertEqual(grouped_succ.status_code, 200)
+        self.assertEqual(len(grouped_succ.data.get("results", [])), 1)
+        self.assertEqual(grouped_succ.data["results"][0]["status"], "SUCCEEDED")
+
+    def test_stats_sequence_run_status_counts_endpoint(self):
+        """Smoke: per-sequence status totals under ``/stats/sequence_run_status_counts/``."""
+        r = self.client.get(self.stats_sequence_run_status_counts_endpoint)
+        self.assertEqual(r.status_code, 200)
+        self.assertGreaterEqual(r.data.get("all", 0), 1)
+
+    def test_instrument_run_status_counts_endpoint(self):
+        r = self.client.get(self.stats_instrument_run_status_counts_endpoint)
+        self.assertEqual(r.status_code, 200)
+        self.assertGreaterEqual(r.data.get("all", 0), 1)
+
+    def test_instrument_run_status_counts_one_per_group(self):
+        """
+        Regression: ``succeeded`` (etc.) must count **instrument runs**, not sequence rows.
+        One group with two sequences and latest status SUCCEEDED must contribute 1 to succeeded.
+        """
+        Sequence.objects.all().delete()
+        ir = "MULTI_SEQ_SAME_INSTR"
+        base = dict(
+            run_volume_name="gds",
+            run_folder_path="/p",
+            run_data_uri="gds://gds/p",
+            sample_sheet_name="SampleSheet.csv",
+            instrument_run_id=ir,
+            api_url="https://bssh.dev/api/v1/runs/x",
+            v1pre3_id="1",
+            ica_project_id="12345678-53ba-47a5-854d-e6b53101adb7",
+            experiment_name="Exp",
+        )
+        Sequence.objects.create(
+            **base,
+            status=SequenceStatus.FAILED,
+            start_time=now() - timedelta(hours=2),
+            sequence_run_id="r.failmulti",
+            sequence_run_name=ir,
+        )
+        Sequence.objects.create(
+            **base,
+            status=SequenceStatus.SUCCEEDED,
+            start_time=now() - timedelta(hours=1),
+            sequence_run_id="r.succmulti",
+            sequence_run_name=ir,
+        )
+        r = self.client.get(self.stats_instrument_run_status_counts_endpoint)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.data.get("all"), 1)
+        self.assertEqual(r.data.get("succeeded"), 1)
+        self.assertEqual(r.data.get("failed"), 0)
+
+    def test_stats_sequence_run_status_counts_matches_list_start_time_filter(self):
+        """
+        ``sequence_run_status_counts`` must apply the same ``start_time`` (gte) semantics as the list API
+        when only ``start_time`` is provided (not both bounds).
+        """
+        empty = self.client.get(
+            f"{self.stats_sequence_run_status_counts_endpoint}?start_time=2099-01-01T00:00:00%2B00:00"
+        )
+        self.assertEqual(empty.status_code, 200)
+        self.assertEqual(empty.data.get("all"), 0)
+
+        hit = self.client.get(
+            f"{self.stats_sequence_run_status_counts_endpoint}?start_time=2020-01-01T00:00:00%2B00:00"
+        )
+        self.assertEqual(hit.status_code, 200)
+        self.assertGreaterEqual(hit.data.get("all", 0), 1)
 
     def test_get_sequence_runs(self):
         """

--- a/app/sequence_run_manager/tests/test_viewsets_utils.py
+++ b/app/sequence_run_manager/tests/test_viewsets_utils.py
@@ -1,0 +1,27 @@
+"""Tests for ``sequence_run_manager.viewsets.utils`` helpers."""
+
+from django.http import QueryDict
+from django.test import SimpleTestCase
+
+from sequence_run_manager.viewsets.utils import build_keyword_params
+
+
+class BuildKeywordParamsTests(SimpleTestCase):
+    def test_blank_only_param_omitted(self):
+        q = QueryDict("workflow_id=")
+        self.assertEqual(build_keyword_params(q), {})
+
+    def test_whitespace_only_param_omitted(self):
+        q = QueryDict(mutable=True)
+        q.setlist("workflow_id", ["  ", "\t"])
+        self.assertEqual(build_keyword_params(q), {})
+
+    def test_strips_and_keeps_non_blank(self):
+        q = QueryDict(mutable=True)
+        q.setlist("workflow_id", ["  a ", "b"])
+        self.assertEqual(build_keyword_params(q), {"workflow_id": ["a", "b"]})
+
+    def test_mixed_blank_and_real_values(self):
+        q = QueryDict(mutable=True)
+        q.setlist("workflow_id", ["", "x", "  "])
+        self.assertEqual(build_keyword_params(q), {"workflow_id": ["x"]})

--- a/app/sequence_run_manager/urls/base.py
+++ b/app/sequence_run_manager/urls/base.py
@@ -19,7 +19,7 @@ router = OptionalSlashDefaultRouter()
 router.register(r"sequence_run", SequenceRunViewSet, basename="sequence-run")
 router.register("sequence_run/(?P<orcabus_id>[^/]+)/comment", CommentViewSet, basename="sequence-run-comment")
 router.register("sequence_run/(?P<orcabus_id>[^/]+)/state", StateViewSet, basename="sequence-run-states")
-router.register(r"sequence_run/stats", SequenceStatsViewSet, basename="sequence-run-stats")
+router.register(r"stats", SequenceStatsViewSet, basename="stats")
 router.register(r"sample_sheet", SampleSheetViewSet, basename="sample-sheet")
 
 # Sequence Run Action

--- a/app/sequence_run_manager/viewsets/base.py
+++ b/app/sequence_run_manager/viewsets/base.py
@@ -1,69 +1,10 @@
 from __future__ import annotations
 
-import logging
 from abc import ABC
-from typing import Any, Optional
-
-import jwt
 
 from sequence_run_manager.pagination import StandardResultsSetPagination
 from rest_framework import filters
-from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.viewsets import ReadOnlyModelViewSet
-
-logger = logging.getLogger(__name__)
-
-def parse_bearer_raw_token_from_request(request, keyword: str = "Bearer") -> Optional[str]:
-    """
-    Extract the JWT string from ``Authorization: Bearer <token>``.
-
-    Returns ``None`` if the header is missing or not a single Bearer token.
-    """
-    header = request.META.get("HTTP_AUTHORIZATION", "")
-    if not header:
-        return None
-
-    parts = header.split()
-    if len(parts) != 2 or parts[0].lower() != keyword.lower():
-        return None
-
-    raw_token = parts[1].strip()
-    return raw_token or None
-
-
-def decode_rs256_jwt_payload_without_verification(raw_token: str) -> dict[str, Any]:
-    """
-    Decode a JWT's payload with alg RS256. Signature is **not** verified.
-
-    Use when an upstream layer (e.g. API Gateway) has already authenticated the caller;
-    this only reads claims such as ``email``.
-    """
-    try:
-        return jwt.decode(
-            raw_token,
-            options={"verify_signature": False},
-            algorithms=["RS256"],
-        )
-    except jwt.PyJWTError as exc:
-        logger.info("JWT decode failed: %s", exc)
-        raise AuthenticationFailed("Invalid token.") from exc
-
-
-def get_email_from_bearer_authorization(request, keyword: str = "Bearer") -> str:
-    """
-    Normalized ``email`` claim from ``Authorization: Bearer <jwt>``.
-
-    Raises:
-        AuthenticationFailed: Missing/malformed Bearer header, invalid token, or no email claim.
-    """
-    raw_token = parse_bearer_raw_token_from_request(request, keyword=keyword)
-    if not raw_token:
-        raise AuthenticationFailed("Authentication credentials were not provided.")
-    payload = decode_rs256_jwt_payload_without_verification(raw_token)
-    email = payload.get("email")
-    if email and isinstance(email, str) and email.strip():
-        return email.strip().lower()
-    raise AuthenticationFailed("Token payload did not contain a valid email claim.")
 
 
 class BaseViewSet(ReadOnlyModelViewSet, ABC):

--- a/app/sequence_run_manager/viewsets/comment.py
+++ b/app/sequence_run_manager/viewsets/comment.py
@@ -7,7 +7,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 from sequence_run_manager.models.comment import Comment, TargetType
 from sequence_run_manager.models.sequence import Sequence
 from sequence_run_manager.serializers.comment import CommentSerializer, CommentCreateRequestSerializer, CommentUpdateRequestSerializer
-from sequence_run_manager.viewsets.base import get_email_from_bearer_authorization
+from sequence_run_manager.viewsets.utils import get_email_from_bearer_authorization
 
 
 @extend_schema_view(

--- a/app/sequence_run_manager/viewsets/sequence_run.py
+++ b/app/sequence_run_manager/viewsets/sequence_run.py
@@ -2,7 +2,6 @@ from drf_spectacular.utils import extend_schema, OpenApiResponse
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework import status
-from rest_framework import filters
 from rest_framework.settings import api_settings
 
 from sequence_run_manager.pagination import StandardResultsSetPagination
@@ -34,17 +33,13 @@ ALLOWED_ORDER_FIELDS = frozenset([
 class SequenceRunViewSet(BaseViewSet):
     serializer_class = SequenceRunSerializer
     search_fields = Sequence.get_base_fields()
-    # Search is applied in ``get_queryset`` via ``sequence_run_manager.viewsets.utils.filtered_sequence_runs_queryset`` (same
-    # text match as stats / ``list_by_instrument_run_id``). Omit ``SearchFilter`` to avoid
-    # double-filtering on the same ``SEARCH_PARAM`` query key.
-    filter_backends = [filters.OrderingFilter]
+    # Ordering is handled exclusively in ``get_queryset`` using the allow-list below.
+    # SearchFilter is also omitted because ``filtered_sequence_runs_queryset`` applies
+    # the same free-text search; having both would double-filter on the same key.
+    filter_backends = []
     queryset = Sequence.objects.all()
     lookup_value_regex = "[^/]+" # to allow id prefix
     lookup_field = 'orcabus_id'
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._has_custom_ordering = False
 
     @staticmethod
     def _validate_ordering(ordering: str | None) -> str | None:
@@ -56,50 +51,23 @@ class SequenceRunViewSet(BaseViewSet):
             return None
         return s
 
-
-    def filter_queryset(self, queryset):
-        """
-        Override to prevent OrderingFilter from applying default ordering
-        when we have a validated ``ordering`` query param (``REST_FRAMEWORK['ORDERING_PARAM']``).
-        """
-        # Check if we have custom ordering (stored in instance variable from get_queryset)
-        if self._has_custom_ordering:
-            # We have custom ordering, so we need to prevent OrderingFilter from applying default ordering
-            # Temporarily store original filter_backends
-            original_backends = self.filter_backends
-            # Filter out OrderingFilter by checking the class type
-            self.filter_backends = [f for f in self.filter_backends if f != filters.OrderingFilter]
-            try:
-                # Apply filters without OrderingFilter
-                queryset = super().filter_queryset(queryset)
-            finally:
-                # Restore original filter_backends
-                self.filter_backends = original_backends
-        else:
-            # No custom ordering, use default behavior
-            queryset = super().filter_queryset(queryset)
-
-        return queryset
-
     def get_queryset(self):
         """
         Same shared filters as ``list_by_instrument_run_id`` and ``stats/sequence_run_status_counts`` (see
         ``sequence_run_manager.viewsets.utils.filtered_sequence_runs_queryset``). The ``status``
         query param filters ``Sequence.status`` on each row. Optional ``ordering``
-        (``REST_FRAMEWORK['ORDERING_PARAM']``) when the value is in the allow-list.
+        (``REST_FRAMEWORK['ORDERING_PARAM']``) when the value is in the allow-list; falls back
+        to the default ``BaseViewSet.ordering`` when absent or invalid.
         """
         raw_order = (self.request.query_params.get(api_settings.ORDERING_PARAM) or "").strip()
         validated_ordering = self._validate_ordering(raw_order)
-        self._has_custom_ordering = validated_ordering is not None
 
         result_set = filtered_sequence_runs_queryset(
             self.request.query_params,
             apply_sequence_status_param=True,
         )
-        if validated_ordering:
-            result_set = result_set.order_by(validated_ordering)
-
-        return result_set
+        ordering = validated_ordering if validated_ordering else self.ordering[0]
+        return result_set.order_by(ordering)
 
     @extend_schema(responses={200: SequenceRunSerializer, 404: OpenApiResponse(description="Sequence run not found.")}, operation_id="get_sequence_run_by_orcabus_id")
     def retrieve(self, request, *args, **kwargs):
@@ -149,13 +117,27 @@ class SequenceRunViewSet(BaseViewSet):
             self.request.query_params,
             apply_sequence_status_param=False,
         )
-        if validated_ordering:
-            sequence_set = sequence_set.order_by(validated_ordering)
 
         grouped_data = instrument_run_groups_queryset(sequence_set)
-        status_filter = self.request.query_params.get("status", "").strip()
+        status_filter = (self.request.query_params.get("status") or "").strip()
         if status_filter:
             grouped_data = grouped_data.filter(group_status=status_filter)
+
+        # Apply ordering to grouped_data; ``status`` maps to the annotated ``group_status``
+        # field.  Fields absent from the grouped queryset (e.g. ``orcabus_id``) are ignored
+        # and the default ``-start_time`` ordering is kept.
+        _GROUP_ORDER_MAP = {
+            "status": "group_status",
+            "-status": "-group_status",
+            "start_time": "start_time",
+            "-start_time": "-start_time",
+            "end_time": "end_time",
+            "-end_time": "-end_time",
+            "instrument_run_id": "instrument_run_id",
+            "-instrument_run_id": "-instrument_run_id",
+        }
+        if validated_ordering and validated_ordering in _GROUP_ORDER_MAP:
+            grouped_data = grouped_data.order_by(_GROUP_ORDER_MAP[validated_ordering])
 
         paginator = StandardResultsSetPagination()
         paginated_groups = paginator.paginate_queryset(grouped_data, request)

--- a/app/sequence_run_manager/viewsets/sequence_run.py
+++ b/app/sequence_run_manager/viewsets/sequence_run.py
@@ -98,7 +98,7 @@ class SequenceRunViewSet(BaseViewSet):
         if order_by:
             result_set = result_set.order_by(order_by)
 
-        return result_set.distinct()
+        return result_set
 
     @extend_schema(responses={200: SequenceRunSerializer, 404: OpenApiResponse(description="Sequence run not found.")}, operation_id="get_sequence_run_by_orcabus_id")
     def retrieve(self, request, *args, **kwargs):

--- a/app/sequence_run_manager/viewsets/sequence_run.py
+++ b/app/sequence_run_manager/viewsets/sequence_run.py
@@ -9,7 +9,12 @@ from sequence_run_manager.pagination import StandardResultsSetPagination
 from django.shortcuts import get_object_or_404
 
 from sequence_run_manager.models import Sequence
-from sequence_run_manager.serializers.sequence_run import SequenceRunSerializer, SequenceRunListParamSerializer, SequenceRunMinSerializer, SequenceRunGroupByInstrumentRunIdSerializer
+from sequence_run_manager.serializers.sequence_run import (
+    SequenceRunSerializer,
+    SequenceRunListQueryParamSerializer,
+    SequenceRunMinSerializer,
+    SequenceRunGroupByInstrumentRunIdSerializer,
+)
 from sequence_run_manager.serializers.sample_sheet import SampleSheetSerializer
 from sequence_run_manager.models.sample_sheet import SampleSheet
 from sequence_run_manager.viewsets.base import BaseViewSet
@@ -31,7 +36,7 @@ class SequenceRunViewSet(BaseViewSet):
     search_fields = Sequence.get_base_fields()
     # Search is applied in ``get_queryset`` via ``sequence_run_manager.viewsets.utils.filtered_sequence_runs_queryset`` (same
     # text match as stats / ``list_by_instrument_run_id``). Omit ``SearchFilter`` to avoid
-    # double-filtering on the same ``search`` query param.
+    # double-filtering on the same ``SEARCH_PARAM`` query key.
     filter_backends = [filters.OrderingFilter]
     queryset = Sequence.objects.all()
     lookup_value_regex = "[^/]+" # to allow id prefix
@@ -55,7 +60,7 @@ class SequenceRunViewSet(BaseViewSet):
     def filter_queryset(self, queryset):
         """
         Override to prevent OrderingFilter from applying default ordering
-        when we have a custom order_by parameter.
+        when we have a validated ``ordering`` query param (``REST_FRAMEWORK['ORDERING_PARAM']``).
         """
         # Check if we have custom ordering (stored in instance variable from get_queryset)
         if self._has_custom_ordering:
@@ -80,23 +85,19 @@ class SequenceRunViewSet(BaseViewSet):
         """
         Same shared filters as ``list_by_instrument_run_id`` and ``stats/sequence_run_status_counts`` (see
         ``sequence_run_manager.viewsets.utils.filtered_sequence_runs_queryset``). The ``status``
-        query param filters ``Sequence.status`` on each row. Optional ``order_by`` / ``ordering``
-        when the value is in the allow-list.
+        query param filters ``Sequence.status`` on each row. Optional ``ordering``
+        (``REST_FRAMEWORK['ORDERING_PARAM']``) when the value is in the allow-list.
         """
-        raw_order = (
-            self.request.query_params.get("order_by")
-            or self.request.query_params.get(api_settings.ORDERING_PARAM)
-            or ""
-        ).strip()
-        order_by = self._validate_ordering(raw_order)
-        self._has_custom_ordering = order_by is not None
+        raw_order = (self.request.query_params.get(api_settings.ORDERING_PARAM) or "").strip()
+        validated_ordering = self._validate_ordering(raw_order)
+        self._has_custom_ordering = validated_ordering is not None
 
         result_set = filtered_sequence_runs_queryset(
             self.request.query_params,
             apply_sequence_status_param=True,
         )
-        if order_by:
-            result_set = result_set.order_by(order_by)
+        if validated_ordering:
+            result_set = result_set.order_by(validated_ordering)
 
         return result_set
 
@@ -114,7 +115,7 @@ class SequenceRunViewSet(BaseViewSet):
 
     @extend_schema(
         parameters=[
-            SequenceRunListParamSerializer
+            SequenceRunListQueryParamSerializer
         ],
         responses={
             200: SequenceRunMinSerializer(many=True)
@@ -126,7 +127,7 @@ class SequenceRunViewSet(BaseViewSet):
 
     @extend_schema(
         parameters=[
-            SequenceRunListParamSerializer
+            SequenceRunListQueryParamSerializer
         ],
         responses={
             200: SequenceRunGroupByInstrumentRunIdSerializer(many=True)
@@ -141,19 +142,15 @@ class SequenceRunViewSet(BaseViewSet):
         sequence in the group (by ``start_time``, then ``orcabus_id``), not each row's field alone.
         Other params match the list endpoint (see ``filtered_sequence_runs_queryset``).
         """
-        raw_order = (
-            self.request.query_params.get("order_by")
-            or self.request.query_params.get(api_settings.ORDERING_PARAM)
-            or ""
-        ).strip()
-        order_by = self._validate_ordering(raw_order)
+        raw_order = (self.request.query_params.get(api_settings.ORDERING_PARAM) or "").strip()
+        validated_ordering = self._validate_ordering(raw_order)
 
         sequence_set = filtered_sequence_runs_queryset(
             self.request.query_params,
             apply_sequence_status_param=False,
         )
-        if order_by:
-            sequence_set = sequence_set.order_by(order_by)
+        if validated_ordering:
+            sequence_set = sequence_set.order_by(validated_ordering)
 
         grouped_data = instrument_run_groups_queryset(sequence_set)
         status_filter = self.request.query_params.get("status", "").strip()

--- a/app/sequence_run_manager/viewsets/sequence_run.py
+++ b/app/sequence_run_manager/viewsets/sequence_run.py
@@ -29,6 +29,21 @@ ALLOWED_ORDER_FIELDS = frozenset([
     'status', '-status',
 ])
 
+# Mapping from per-sequence ordering fields to the annotated fields used in the
+# instrument-run grouped queryset.  Fields absent here (e.g. ``orcabus_id``) are
+# not in the grouped result and are intentionally omitted so ordering falls back
+# to the default ``-start_time``.
+_GROUP_ORDER_MAP = {
+    "status": "group_status",
+    "-status": "-group_status",
+    "start_time": "start_time",
+    "-start_time": "-start_time",
+    "end_time": "end_time",
+    "-end_time": "-end_time",
+    "instrument_run_id": "instrument_run_id",
+    "-instrument_run_id": "-instrument_run_id",
+}
+
 
 class SequenceRunViewSet(BaseViewSet):
     serializer_class = SequenceRunSerializer
@@ -126,16 +141,6 @@ class SequenceRunViewSet(BaseViewSet):
         # Apply ordering to grouped_data; ``status`` maps to the annotated ``group_status``
         # field.  Fields absent from the grouped queryset (e.g. ``orcabus_id``) are ignored
         # and the default ``-start_time`` ordering is kept.
-        _GROUP_ORDER_MAP = {
-            "status": "group_status",
-            "-status": "-group_status",
-            "start_time": "start_time",
-            "-start_time": "-start_time",
-            "end_time": "end_time",
-            "-end_time": "-end_time",
-            "instrument_run_id": "instrument_run_id",
-            "-instrument_run_id": "-instrument_run_id",
-        }
         if validated_ordering and validated_ordering in _GROUP_ORDER_MAP:
             grouped_data = grouped_data.order_by(_GROUP_ORDER_MAP[validated_ordering])
 

--- a/app/sequence_run_manager/viewsets/sequence_run.py
+++ b/app/sequence_run_manager/viewsets/sequence_run.py
@@ -4,53 +4,99 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework import filters
 from rest_framework.settings import api_settings
-from sequence_run_manager.viewsets.base import BaseViewSet
+
 from sequence_run_manager.pagination import StandardResultsSetPagination
-from django.db.models import Q, Count, Min, Max
-from sequence_run_manager.models import Sequence, LibraryAssociation
+from django.shortcuts import get_object_or_404
+
+from sequence_run_manager.models import Sequence
 from sequence_run_manager.serializers.sequence_run import SequenceRunSerializer, SequenceRunListParamSerializer, SequenceRunMinSerializer, SequenceRunGroupByInstrumentRunIdSerializer
 from sequence_run_manager.serializers.sample_sheet import SampleSheetSerializer
 from sequence_run_manager.models.sample_sheet import SampleSheet
-from django.shortcuts import get_object_or_404
+from sequence_run_manager.viewsets.base import BaseViewSet
+from sequence_run_manager.viewsets.utils import (
+    filtered_sequence_runs_queryset,
+    instrument_run_groups_queryset,
+)
+
+# Allowed ordering fields for ongoing/unresolved actions (with optional - prefix)
+ALLOWED_ORDER_FIELDS = frozenset([
+    'orcabus_id', '-orcabus_id', 'instrument_run_id', '-instrument_run_id',
+    'start_time', '-start_time', 'end_time', '-end_time',
+    'status', '-status',
+])
 
 
 class SequenceRunViewSet(BaseViewSet):
     serializer_class = SequenceRunSerializer
     search_fields = Sequence.get_base_fields()
+    # Search is applied in ``get_queryset`` via ``sequence_run_manager.viewsets.utils.filtered_sequence_runs_queryset`` (same
+    # text match as stats / ``list_by_instrument_run_id``). Omit ``SearchFilter`` to avoid
+    # double-filtering on the same ``search`` query param.
+    filter_backends = [filters.OrderingFilter]
     queryset = Sequence.objects.all()
     lookup_value_regex = "[^/]+" # to allow id prefix
     lookup_field = 'orcabus_id'
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._has_custom_ordering = False
+
+    @staticmethod
+    def _validate_ordering(ordering: str | None) -> str | None:
+        """Return a safe ordering value, or None if missing / not in the allow-list."""
+        if not ordering or not isinstance(ordering, str):
+            return None
+        s = ordering.strip()
+        if not s or s not in ALLOWED_ORDER_FIELDS:
+            return None
+        return s
+
+
+    def filter_queryset(self, queryset):
+        """
+        Override to prevent OrderingFilter from applying default ordering
+        when we have a custom order_by parameter.
+        """
+        # Check if we have custom ordering (stored in instance variable from get_queryset)
+        if self._has_custom_ordering:
+            # We have custom ordering, so we need to prevent OrderingFilter from applying default ordering
+            # Temporarily store original filter_backends
+            original_backends = self.filter_backends
+            # Filter out OrderingFilter by checking the class type
+            self.filter_backends = [f for f in self.filter_backends if f != filters.OrderingFilter]
+            try:
+                # Apply filters without OrderingFilter
+                queryset = super().filter_queryset(queryset)
+            finally:
+                # Restore original filter_backends
+                self.filter_backends = original_backends
+        else:
+            # No custom ordering, use default behavior
+            queryset = super().filter_queryset(queryset)
+
+        return queryset
+
     def get_queryset(self):
         """
-        custom query params:
-        start_time: start time of the sequence run
-        end_time: end time of the sequence run
-
-        library_id: library id of the sequence run
+        Same shared filters as ``list_by_instrument_run_id`` and ``stats/sequence_run_status_counts`` (see
+        ``sequence_run_manager.viewsets.utils.filtered_sequence_runs_queryset``). The ``status``
+        query param filters ``Sequence.status`` on each row. Optional ``order_by`` / ``ordering``
+        when the value is in the allow-list.
         """
+        raw_order = (
+            self.request.query_params.get("order_by")
+            or self.request.query_params.get(api_settings.ORDERING_PARAM)
+            or ""
+        ).strip()
+        order_by = self._validate_ordering(raw_order)
+        self._has_custom_ordering = order_by is not None
 
-        start_time = self.request.query_params.get('start_time', 0)
-        end_time = self.request.query_params.get('end_time', 0)
-        library_id = self.request.query_params.get('library_id', 0)
-
-        # exclude the custom query params from the rest of the query params
-        def exclude_params(params):
-            for param in params:
-                self.request.query_params.pop(param) if param in self.request.query_params.keys() else None
-
-        exclude_params([
-            'start_time',
-            'end_time',
-            'library_id',
-        ])
-        result_set = Sequence.objects.get_by_keyword(**self.request.query_params).distinct().filter(status__isnull=False) # filter out fake sequence runs
-
-        if start_time and end_time:
-            result_set = result_set.filter(Q(start_time__range=[start_time, end_time]) | Q(end_time__range=[start_time, end_time]))
-        if library_id:
-            sequence_ids = LibraryAssociation.objects.filter(library_id=library_id).values_list('sequence_id', flat=True)
-            result_set = result_set.filter(orcabus_id__in=sequence_ids)
+        result_set = filtered_sequence_runs_queryset(
+            self.request.query_params,
+            apply_sequence_status_param=True,
+        )
+        if order_by:
+            result_set = result_set.order_by(order_by)
 
         return result_set.distinct()
 
@@ -66,91 +112,76 @@ class SequenceRunViewSet(BaseViewSet):
         sequence = get_object_or_404(Sequence, orcabus_id=orcabus_id)
         return Response(SequenceRunSerializer(sequence).data, status=status.HTTP_200_OK)
 
-    @extend_schema(parameters=[
-        SequenceRunListParamSerializer
-    ])
+    @extend_schema(
+        parameters=[
+            SequenceRunListParamSerializer
+        ],
+        responses={
+            200: SequenceRunMinSerializer(many=True)
+        }
+    )
     def list(self, request, *args, **kwargs):
         self.serializer_class = SequenceRunMinSerializer
         return super().list(request, *args, **kwargs)
 
-    @extend_schema(parameters=[
-        SequenceRunListParamSerializer
-    ],
-    responses={
-        200: StandardResultsSetPagination().get_paginated_response_schema(SequenceRunGroupByInstrumentRunIdSerializer().get_schema())}
+    @extend_schema(
+        parameters=[
+            SequenceRunListParamSerializer
+        ],
+        responses={
+            200: SequenceRunGroupByInstrumentRunIdSerializer(many=True)
+        }
     )
 
     @action(detail=False, methods=["get"], url_name="list_by_instrument_run_id", url_path="list_by_instrument_run_id")
     def list_by_instrument_run_id(self, request, *args, **kwargs):
         """
-        Group sequences by instrument_run_id and return with items array
-        custom query params:
-        start_time: start time of the sequence run
-        end_time: end time of the sequence run
-        library_id: library id of the sequence run
-        page: page number for pagination
-        rows_per_page: number of items per page
+        Group sequences by instrument_run_id and return with items array.
+        The ``status`` query param filters by the **group** status: the ``status`` of the latest
+        sequence in the group (by ``start_time``, then ``orcabus_id``), not each row's field alone.
+        Other params match the list endpoint (see ``filtered_sequence_runs_queryset``).
         """
-        start_time = self.request.query_params.get('start_time', 0)
-        end_time = self.request.query_params.get('end_time', 0)
+        raw_order = (
+            self.request.query_params.get("order_by")
+            or self.request.query_params.get(api_settings.ORDERING_PARAM)
+            or ""
+        ).strip()
+        order_by = self._validate_ordering(raw_order)
 
-        # Extract search term before excluding params
-        search_term = self.request.query_params.get(api_settings.SEARCH_PARAM)
+        sequence_set = filtered_sequence_runs_queryset(
+            self.request.query_params,
+            apply_sequence_status_param=False,
+        )
+        if order_by:
+            sequence_set = sequence_set.order_by(order_by)
 
-        # exclude the custom query params from the rest of the query params
-        def exclude_params(params):
-            for param in params:
-                self.request.query_params.pop(param) if param in self.request.query_params.keys() else None
+        grouped_data = instrument_run_groups_queryset(sequence_set)
+        status_filter = self.request.query_params.get("status", "").strip()
+        if status_filter:
+            grouped_data = grouped_data.filter(group_status=status_filter)
 
-        exclude_params([
-            'start_time',
-            'end_time',
-        ])
-
-        # Get all sequences using get_by_keyword (this excludes search param internally)
-        sequence_set = Sequence.objects.get_by_keyword(**self.request.query_params).distinct()
-
-        # Manually apply search filter if search parameter is provided (This is needed because custom actions don't go through DRF's filter_backends)
-        if search_term and self.search_fields:
-            search_filter = filters.SearchFilter()
-            search_filter.search_fields = self.search_fields
-            sequence_set = search_filter.filter_queryset(self.request, sequence_set, self)
-
-        # Apply time filters if provided
-        if start_time and end_time:
-            sequence_set = sequence_set.filter(Q(start_time__range=[start_time, end_time]) | Q(end_time__range=[start_time, end_time]))
-
-        # Group by instrument_run_id and get aggregated data
-        grouped_data = sequence_set.values('instrument_run_id').annotate(
-            count=Count('instrument_run_id'),
-            start_time=Min('start_time'),
-            end_time=Max('end_time')
-        ).distinct().order_by('-start_time')
-
-        # Apply pagination to the grouped QuerySet first
         paginator = StandardResultsSetPagination()
         paginated_groups = paginator.paginate_queryset(grouped_data, request)
 
-        # Build the response with items array for the paginated groups
         result = []
         for group in paginated_groups:
-            instrument_run_id = group['instrument_run_id']
-            if instrument_run_id:  # Only include if instrument_run_id is not None
-                # Get all sequences for this instrument_run_id
-                sequences = sequence_set.filter(instrument_run_id=instrument_run_id).order_by('start_time')
-                sequence_status = sequences.filter(status__isnull=False).order_by('start_time').last().status
+            instrument_run_id = group["instrument_run_id"]
+            if not instrument_run_id:
+                continue
+            sequences = sequence_set.filter(instrument_run_id=instrument_run_id).order_by("start_time")
+            sequence_status = group.get("group_status")
+            sequence_items = SequenceRunMinSerializer(sequences, many=True).data
 
-                # Convert sequences to list of dictionaries manually
-                sequence_items = SequenceRunMinSerializer(sequences, many=True).data
-
-                result.append({
-                    'instrument_run_id': instrument_run_id,
-                    'start_time': group['start_time'],
-                    'end_time': group['end_time'],
-                    'count': group['count'],
-                    'status': sequence_status,
-                    'items': sequence_items
-                })
+            result.append(
+                {
+                    "instrument_run_id": instrument_run_id,
+                    "start_time": group["start_time"],
+                    "end_time": group["end_time"],
+                    "count": group["count"],
+                    "status": sequence_status,
+                    "items": sequence_items,
+                }
+            )
 
         return paginator.get_paginated_response(result)
 

--- a/app/sequence_run_manager/viewsets/sequence_run_stats.py
+++ b/app/sequence_run_manager/viewsets/sequence_run_stats.py
@@ -1,11 +1,13 @@
 from django.db import models
-from django.db.models import Q
 from drf_spectacular.utils import extend_schema
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from sequence_run_manager.models.sequence import Sequence, LibraryAssociation
+from sequence_run_manager.viewsets.utils import (
+    filtered_sequence_runs_queryset,
+    instrument_run_groups_queryset,
+)
 from sequence_run_manager.serializers.sequence_run import (
     SequenceRunCountByStatusSerializer,
     SequenceRunListParamSerializer,
@@ -14,63 +16,28 @@ from sequence_run_manager.serializers.sequence_run import (
 
 class SequenceStatsViewSet(GenericViewSet):
     """
-    ViewSet for sequence-related statistics.
+    Sequence-run statistics at ``GET /api/v1/stats/sequence_run_status_counts/`` and
+    ``GET /api/v1/stats/instrument_run_status_counts/`` (same filter query params as list endpoints).
     """
 
     def get_queryset(self):
         """
-        Build sequence queryset using sequence-run list semantics:
-        - keyword filters via `Sequence.objects.get_by_keyword`
-        - optional time filters via sequence `start_time`/`end_time`
-        - optional `library_id` filter
-        - fake sequence runs are excluded (`status__isnull=False`)
+        Filters for **per-sequence** ``sequence_run_status_counts``: same as ``GET /sequence_run/`` —
+        ``status`` applies to ``Sequence.status`` on each row (see
+        ``filtered_sequence_runs_queryset`` with default ``apply_sequence_status_param``).
         """
-        start_time = self.request.query_params.get("start_time", "")
-        end_time = self.request.query_params.get("end_time", "")
-
-        library_id = self.request.query_params.get("library_id", "")
-
-        # Custom query params that are not direct Sequence fields for get_by_keyword.
-        exclude_keys = {
-            "start_time",
-            "end_time",
-            "search",
-            "order_by",
-            "library_id",
-        }
-        keyword_params = {
-            key: value
-            for key, value in self.request.query_params.items()
-            if key not in exclude_keys
-        }
-
-        result_set = (
-            Sequence.objects.get_by_keyword(**keyword_params)
-            .distinct()
-            .filter(status__isnull=False)  # filter out fake sequence runs
+        return filtered_sequence_runs_queryset(
+            self.request.query_params,
+            apply_sequence_status_param=True,
         )
-
-        if library_id:
-            sequence_ids = (
-                LibraryAssociation.objects.filter(library_id=library_id)
-                .values_list("sequence_id", flat=True)
-            )
-            result_set = result_set.filter(orcabus_id__in=sequence_ids)
-
-        if start_time and end_time:
-            result_set = result_set.filter(
-                Q(start_time__range=[start_time, end_time])
-                | Q(end_time__range=[start_time, end_time])
-            )
-
-        return result_set
 
     @extend_schema(
         parameters=[SequenceRunListParamSerializer],
         responses=SequenceRunCountByStatusSerializer,
+        operation_id="stats_sequence_run_status_counts",
     )
-    @action(detail=False, methods=["GET"])
-    def status_counts(self, request):
+    @action(detail=False, methods=["GET"], url_path="sequence_run_status_counts")
+    def sequence_run_status_counts(self, request):
         queryset = self.get_queryset()
         status_counts = queryset.values("status").annotate(count=models.Count("status"))
 
@@ -94,3 +61,49 @@ class SequenceStatsViewSet(GenericViewSet):
             counts,
             status=200,
         )
+
+    @extend_schema(
+        parameters=[SequenceRunListParamSerializer],
+        responses=SequenceRunCountByStatusSerializer,
+        operation_id="stats_instrument_run_status_counts",
+    )
+    @action(detail=False, methods=["GET"], url_path="instrument_run_status_counts")
+    def instrument_run_status_counts(self, request):
+        """
+        Counts by **instrument-run group** status (same definition as
+        ``list_by_instrument_run_id`` ``status`` field): latest non-null ``Sequence.status``
+        within each ``instrument_run_id``. Query params match the grouped list except
+        ``status`` filters groups by that computed value. ``all`` is the number of groups.
+        """
+        sequence_set = filtered_sequence_runs_queryset(
+            request.query_params,
+            apply_sequence_status_param=False,
+        )
+        grouped = instrument_run_groups_queryset(sequence_set)
+        status_filter = request.query_params.get("status", "").strip()
+        if status_filter:
+            grouped = grouped.filter(group_status=status_filter)
+
+        counts = {
+            "all": grouped.count(),
+            "started": 0,
+            "succeeded": 0,
+            "failed": 0,
+            "aborted": 0,
+            "resolved": 0,
+            "deprecated": 0,
+        }
+
+        # Count distinct instrument runs per group_status. Without ``distinct=True``, a second
+        # ``values().annotate`` can join ``Sequence`` again and count one row per *sequence*,
+        # inflating e.g. SUCCEEDED when one instrument run has several sequence rows.
+        per_status = grouped.values("group_status").annotate(
+            count=models.Count("instrument_run_id", distinct=True)
+        )
+        for item in per_status:
+            if item["group_status"] is not None:
+                key = item["group_status"].lower()
+                if key in counts:
+                    counts[key] = item["count"]
+
+        return Response(counts, status=200)

--- a/app/sequence_run_manager/viewsets/sequence_run_stats.py
+++ b/app/sequence_run_manager/viewsets/sequence_run_stats.py
@@ -10,7 +10,7 @@ from sequence_run_manager.viewsets.utils import (
 )
 from sequence_run_manager.serializers.sequence_run import (
     SequenceRunCountByStatusSerializer,
-    SequenceRunListParamSerializer,
+    SequenceRunListQueryParamSerializer,
 )
 
 
@@ -32,7 +32,7 @@ class SequenceStatsViewSet(GenericViewSet):
         )
 
     @extend_schema(
-        parameters=[SequenceRunListParamSerializer],
+        parameters=[SequenceRunListQueryParamSerializer],
         responses=SequenceRunCountByStatusSerializer,
         operation_id="stats_sequence_run_status_counts",
     )
@@ -63,7 +63,7 @@ class SequenceStatsViewSet(GenericViewSet):
         )
 
     @extend_schema(
-        parameters=[SequenceRunListParamSerializer],
+        parameters=[SequenceRunListQueryParamSerializer],
         responses=SequenceRunCountByStatusSerializer,
         operation_id="stats_instrument_run_status_counts",
     )

--- a/app/sequence_run_manager/viewsets/utils.py
+++ b/app/sequence_run_manager/viewsets/utils.py
@@ -1,0 +1,203 @@
+"""
+Shared helpers for viewsets: JWT/Bearer parsing and sequence-run list query building.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+import jwt
+from django.db.models import Count, Max, Min, OuterRef, Q, QuerySet, Subquery
+from django.utils.dateparse import parse_datetime
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.settings import api_settings
+
+from sequence_run_manager.pagination import PaginationConstant
+from sequence_run_manager.models import Sequence, LibraryAssociation
+
+logger = logging.getLogger(__name__)
+
+
+# --- Bearer / JWT (used by comment and similar viewsets) ---
+
+
+def parse_bearer_raw_token_from_request(request, keyword: str = "Bearer") -> Optional[str]:
+    """
+    Extract the JWT string from ``Authorization: Bearer <token>``.
+
+    Returns ``None`` if the header is missing or not a single Bearer token.
+    """
+    header = request.META.get("HTTP_AUTHORIZATION", "")
+    if not header:
+        return None
+
+    parts = header.split()
+    if len(parts) != 2 or parts[0].lower() != keyword.lower():
+        return None
+
+    raw_token = parts[1].strip()
+    return raw_token or None
+
+
+def decode_rs256_jwt_payload_without_verification(raw_token: str) -> dict[str, Any]:
+    """
+    Decode a JWT's payload with alg RS256. Signature is **not** verified.
+
+    Use when an upstream layer (e.g. API Gateway) has already authenticated the caller;
+    this only reads claims such as ``email``.
+    """
+    try:
+        return jwt.decode(
+            raw_token,
+            options={"verify_signature": False},
+            algorithms=["RS256"],
+        )
+    except jwt.PyJWTError as exc:
+        logger.info("JWT decode failed: %s", exc)
+        raise AuthenticationFailed("Invalid token.") from exc
+
+
+def get_email_from_bearer_authorization(request, keyword: str = "Bearer") -> str:
+    """
+    Normalized ``email`` claim from ``Authorization: Bearer <jwt>``.
+
+    Raises:
+        AuthenticationFailed: Missing/malformed Bearer header, invalid token, or no email claim.
+    """
+    raw_token = parse_bearer_raw_token_from_request(request, keyword=keyword)
+    if not raw_token:
+        raise AuthenticationFailed("Authentication credentials were not provided.")
+    payload = decode_rs256_jwt_payload_without_verification(raw_token)
+    email = payload.get("email")
+    if email and isinstance(email, str) and email.strip():
+        return email.strip().lower()
+    raise AuthenticationFailed("Token payload did not contain a valid email claim.")
+
+
+# --- Sequence run list-style query (list / list_by_instrument_run_id / stats) ---
+
+# Query params handled by views / DRF — never pass through to ``get_by_keyword`` / ORM iexact stack.
+SEQUENCE_RUN_NON_KEYWORD_QUERY_PARAMS = frozenset(
+    {
+        "start_time",
+        "end_time",
+        "library_id",
+        "status",
+        "search",
+        "order_by",
+        api_settings.ORDERING_PARAM,
+        PaginationConstant.PAGE,
+        PaginationConstant.ROWS_PER_PAGE,
+        "sortCol",
+        "sortAsc",
+    }
+)
+
+
+def parse_datetime_safe(value: Optional[str]) -> Optional[datetime]:
+    if not value or not isinstance(value, str):
+        return None
+    return parse_datetime(value.strip())
+
+
+def build_keyword_params(query_params) -> dict[str, list[str]]:
+    """Use getlist so multiple values per key are preserved (e.g. repeated workflow ids)."""
+    return {
+        k: query_params.getlist(k)
+        for k in query_params
+        if k not in SEQUENCE_RUN_NON_KEYWORD_QUERY_PARAMS and query_params.getlist(k)
+    }
+
+
+def _sequence_run_search_q(term: str) -> Q:
+    """
+    Search query for sequence run search, iexact search on orcabus_id, instrument_run_id, sequence_run_id, sequence_run_name, experiment_name, and sample_sheet_name
+    """
+    return (
+        Q(orcabus_id__icontains=term)
+        | Q(instrument_run_id__icontains=term)
+        | Q(sequence_run_id__icontains=term)
+        | Q(sequence_run_name__icontains=term)
+        | Q(experiment_name__icontains=term)
+        | Q(sample_sheet_name__icontains=term)
+    )
+
+
+def filtered_sequence_runs_queryset(
+    query_params,
+    *,
+    apply_sequence_status_param: bool = True,
+) -> QuerySet:
+    """
+    Keyword filters, exclude fake runs (``status`` null), optional ``start_time`` / ``end_time``
+    (parsed datetimes, applied to ``Sequence.start_time`` as gte/lte), ``library_id``,
+    optional ``status`` on ``Sequence.status`` (only when ``apply_sequence_status_param`` is True),
+    and free-text ``search`` (DRF search param name).
+
+    For ``list_by_instrument_run_id`` / instrument-run stats, pass
+    ``apply_sequence_status_param=False`` so ``status`` filters the **group** status instead.
+    """
+    keyword_params = build_keyword_params(query_params)
+    qs = (
+        Sequence.objects.get_by_keyword(**keyword_params)
+        .distinct()
+        .filter(status__isnull=False)
+    )
+
+    start_time = query_params.get("start_time")
+    end_time = query_params.get("end_time")
+    start_dt = parse_datetime_safe(start_time) if start_time else None
+    end_dt = parse_datetime_safe(end_time) if end_time else None
+    if start_dt:
+        qs = qs.filter(start_time__gte=start_dt)
+    if end_dt:
+        qs = qs.filter(start_time__lte=end_dt)
+
+    library_id = query_params.get("library_id")
+    if library_id:
+        sequence_ids = LibraryAssociation.objects.filter(library_id=library_id).values_list(
+            "sequence_id", flat=True
+        )
+        qs = qs.filter(orcabus_id__in=sequence_ids)
+
+    if apply_sequence_status_param:
+        status_filter = query_params.get("status", "")
+        if status_filter:
+            qs = qs.filter(status=status_filter)
+
+    search_term = query_params.get(api_settings.SEARCH_PARAM, "") or ""
+    if search_term:
+        qs = qs.filter(_sequence_run_search_q(search_term))
+
+    return qs
+
+
+def instrument_run_groups_queryset(sequence_set: QuerySet) -> QuerySet:
+    """
+    One row per non-empty ``instrument_run_id`` in ``sequence_set``, with the same aggregates as
+    ``list_by_instrument_run_id`` plus ``group_status``: ``status`` of the row with latest
+    ``start_time`` (ties broken by ``orcabus_id`` desc), among rows with non-null ``status``.
+    """
+    latest_status_sq = Subquery(
+        sequence_set.filter(
+            instrument_run_id=OuterRef("instrument_run_id"),
+            status__isnull=False,
+        )
+        .order_by("-start_time", "-orcabus_id")
+        .values("status")[:1]
+    )
+    return (
+        sequence_set.filter(instrument_run_id__isnull=False)
+        .exclude(instrument_run_id="")
+        .values("instrument_run_id")
+        .annotate(
+            # Distinct sequence rows (avoids duplicate joins); matches rows in ``items``.
+            count=Count("orcabus_id", distinct=True),
+            start_time=Min("start_time"),
+            end_time=Max("end_time"),
+            group_status=latest_status_sq,
+        )
+        .order_by("-start_time")
+    )

--- a/app/sequence_run_manager/viewsets/utils.py
+++ b/app/sequence_run_manager/viewsets/utils.py
@@ -103,17 +103,33 @@ def parse_datetime_safe(value: Optional[str]) -> Optional[datetime]:
 
 
 def build_keyword_params(query_params) -> dict[str, list[str]]:
-    """Use getlist so multiple values per key are preserved (e.g. repeated workflow ids)."""
-    return {
-        k: query_params.getlist(k)
-        for k in query_params
-        if k not in SEQUENCE_RUN_NON_KEYWORD_QUERY_PARAMS and query_params.getlist(k)
-    }
+    """
+    Build keyword args for ``get_by_keyword`` / ``get_model_fields_query``.
+
+    Uses ``getlist`` so repeated keys stay as multiple values (e.g. several workflow ids).
+    Each value is stripped; blanks are dropped. A key is omitted entirely if every value
+    is blank, so we never apply ``field__iexact=''`` from params like ``?workflow_id=``.
+    """
+    out: dict[str, list[str]] = {}
+    for k in query_params:
+        if k in SEQUENCE_RUN_NON_KEYWORD_QUERY_PARAMS:
+            continue
+        raw = query_params.getlist(k)
+        if not raw:
+            continue
+        values: list[str] = []
+        for v in raw:
+            s = v.strip() if isinstance(v, str) else str(v).strip()
+            if s:
+                values.append(s)
+        if values:
+            out[k] = values
+    return out
 
 
 def _sequence_run_search_q(term: str) -> Q:
     """
-    Search query for sequence run search, iexact search on orcabus_id, instrument_run_id, sequence_run_id, sequence_run_name, experiment_name, and sample_sheet_name
+    Search query for sequence runs using a case-insensitive substring match on orcabus_id, instrument_run_id, sequence_run_id, sequence_run_name, experiment_name, and sample_sheet_name
     """
     return (
         Q(orcabus_id__icontains=term)

--- a/app/sequence_run_manager/viewsets/utils.py
+++ b/app/sequence_run_manager/viewsets/utils.py
@@ -159,7 +159,7 @@ def filtered_sequence_runs_queryset(
     Raises:
         ValidationError: If ``status`` is present and non-blank but not a ``SequenceStatus`` value.
     """
-    status_filter = query_params.get("status", "")
+    status_filter = (query_params.get("status") or "").strip()
     if status_filter and status_filter not in SEQUENCE_STATUS_QUERY_VALUES:
         raise ValidationError(f"Invalid status value: {status_filter}")
 

--- a/app/sequence_run_manager/viewsets/utils.py
+++ b/app/sequence_run_manager/viewsets/utils.py
@@ -11,13 +11,15 @@ from typing import Any, Optional
 import jwt
 from django.db.models import Count, Max, Min, OuterRef, Q, QuerySet, Subquery
 from django.utils.dateparse import parse_datetime
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import AuthenticationFailed, ValidationError
 from rest_framework.settings import api_settings
 
 from sequence_run_manager.pagination import PaginationConstant
-from sequence_run_manager.models import Sequence, LibraryAssociation
+from sequence_run_manager.models import Sequence, SequenceStatus, LibraryAssociation
 
 logger = logging.getLogger(__name__)
+
+SEQUENCE_STATUS_QUERY_VALUES = frozenset(member.value for member in SequenceStatus)
 
 
 # --- Bearer / JWT (used by comment and similar viewsets) ---
@@ -85,9 +87,8 @@ SEQUENCE_RUN_NON_KEYWORD_QUERY_PARAMS = frozenset(
         "end_time",
         "library_id",
         "status",
-        "search",
-        "order_by",
         api_settings.ORDERING_PARAM,
+        api_settings.SEARCH_PARAM,
         PaginationConstant.PAGE,
         PaginationConstant.ROWS_PER_PAGE,
         "sortCol",
@@ -150,11 +151,18 @@ def filtered_sequence_runs_queryset(
     Keyword filters, exclude fake runs (``status`` null), optional ``start_time`` / ``end_time``
     (parsed datetimes, applied to ``Sequence.start_time`` as gte/lte), ``library_id``,
     optional ``status`` on ``Sequence.status`` (only when ``apply_sequence_status_param`` is True),
-    and free-text ``search`` (DRF search param name).
+    and free-text search using ``api_settings.SEARCH_PARAM`` (default ``search``).
 
     For ``list_by_instrument_run_id`` / instrument-run stats, pass
     ``apply_sequence_status_param=False`` so ``status`` filters the **group** status instead.
+
+    Raises:
+        ValidationError: If ``status`` is present and non-blank but not a ``SequenceStatus`` value.
     """
+    status_filter = query_params.get("status", "")
+    if status_filter and status_filter not in SEQUENCE_STATUS_QUERY_VALUES:
+        raise ValidationError(f"Invalid status value: {status_filter}")
+
     keyword_params = build_keyword_params(query_params)
     qs = (
         Sequence.objects.get_by_keyword(**keyword_params)
@@ -179,7 +187,6 @@ def filtered_sequence_runs_queryset(
         qs = qs.filter(orcabus_id__in=sequence_ids)
 
     if apply_sequence_status_param:
-        status_filter = query_params.get("status", "")
         if status_filter:
             qs = qs.filter(status=status_filter)
 

--- a/app/sequence_run_manager_proc/services/sequence_library_srv.py
+++ b/app/sequence_run_manager_proc/services/sequence_library_srv.py
@@ -267,7 +267,7 @@ def update_sequence_run_libraries_linking_from_srllc_event(event_detail: dict):
 #         query_param_string = f'&{field_name}='.join(array_to_process)
 #         query_param_string = f'?{field_name}=' + query_param_string  # Appending name at the beginning
 
-#         query_param_string = query_param_string + f'&rowsPerPage=1000'  # Add Rows per page (1000 is the maximum rows)
+#         query_param_string = query_param_string + f'&rows_per_page=1000'  # Add rows per page (1000 is the maximum rows)
 
 #         url = f"https://{METADATA_DOMAIN_NAME.strip('.')}/{METADATA_API_PATH.strip('/')}/{query_param_string}"
 #         # Make sure no data is left, looping data until the end


### PR DESCRIPTION
### Summary
Aligns sequence-run list, list-by-instrument-run, and stats behavior on one shared filter layer, fixes several query/pagination bugs, separates per-sequence vs per-instrument-run status semantics, and moves stats to a dedicated /stats/ API namespace with clearer names.

### Problem
`list_by_instrument_run_id` passed raw query params into get_by_keyword, so pagination and time params could hit the ORM as invalid fields or wrong filters (e.g. empty results).
`status_counts` used different time/filter rules than the list APIs.
Stats lived under a nested path; names were easy to confuse with grouped counts.

### Solution
**Shared filtering (viewsets/utils.py)**
`filtered_sequence_runs_queryset`: keyword filters via get_by_keyword + getlist, excludes non-field params, start_time / end_time as parsed gte/lte on Sequence.start_time, library_id, search, optional apply_sequence_status_param for status (sequence row vs group semantics).
`instrument_run_groups_queryset`: one row per instrument_run_id with group_status = latest non-null status by start_time / orcabus_id (matches grouped list).

**SequenceRunViewSet**
List uses shared filter + status on Sequence.status; SearchFilter removed to avoid double-applying search.
`list_by_instrument_run_id`: shared filter with apply_sequence_status_param=False, status filters group_status, grouping via instrument_run_groups_queryset; ordering validation ignores invalid values instead of silently substituting a default.

### Behavior notes
- stats routes now live under `/api/v1/stats/` instead of `/api/v1/sequence_run/stats/`
- query handling is now consistent across list and stats endpoints.

**New endpoints**
| Method | Path | Description |
| --- | --- | --- |
| `GET` | `/api/v1/stats/sequence_run_status_counts/` | Sequence runs by latest state: `all`, `started`, `succeeded`, `failed`, `aborted`, `resolved`, `deprecated`. Uses the same filter/query semantics as `GET /api/v1/sequence_run/`. |
| `GET` | `/api/v1/stats/instrument_run_status_counts/` | Instrument-run groups by latest sequence status in each `instrument_run_id` group, using the same buckets. `all` is the number of groups, not the number of sequence rows. |

