### PR TITLE
sequence runs status update issue

### DIFF
--- a/app/sequence_run_manager/tests/test_viewsets.py
+++ b/app/sequence_run_manager/tests/test_viewsets.py
@@ -457,6 +457,8 @@ class SequenceViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["status"], "RESOLVED")
         self.assertEqual(response.data["comment"], "Handled")
+        sequence_run.refresh_from_db()
+        self.assertEqual(sequence_run.status, "RESOLVED", "Sequence status should be updated to RESOLVED")
 
     def test_create_state_deprecated_after_succeeded(self):
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
@@ -473,6 +475,8 @@ class SequenceViewSetTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["status"], "DEPRECATED")
+        sequence_run.refresh_from_db()
+        self.assertEqual(sequence_run.status, "DEPRECATED", "Sequence status should be updated to DEPRECATED")
 
     def test_create_state_only_deprecated_when_no_prior_states(self):
         orphan = Sequence.objects.create(

--- a/app/sequence_run_manager/viewsets/state.py
+++ b/app/sequence_run_manager/viewsets/state.py
@@ -88,13 +88,22 @@ class StateViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, mixins.List
             if not self._validate_state_status(latest_status, request_status):
                 return Response({"detail": "Invalid state request. Can't add state '{}' to '{}'".format(request_status, latest_status)},
                                 status=status.HTTP_400_BAD_REQUEST)
+        # create state
+        try:
+            instance = State.objects.create(
+                sequence=sequence,
+                status=request_status,
+                timestamp=timezone.now(),
+                comment=request_comment,
+            )
+        except Exception as e:
+            return Response({"detail": "Failed to create state. Error: {}".format(str(e))},
+                            status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        instance = State.objects.create(
-            sequence=sequence,
-            status=request_status,
-            timestamp=timezone.now(),
-            comment=request_comment,
-        )
+        # update sequence status if the new state is in states_transition_validation_map
+        if request_status in self.states_transition_validation_map:
+            sequence.status = request_status
+            sequence.save(update_fields=["status"])
 
         data = StateSerializer(instance).data
         headers = self.get_success_headers(data)

--- a/app/sequence_run_manager/viewsets/state.py
+++ b/app/sequence_run_manager/viewsets/state.py
@@ -1,12 +1,17 @@
+import logging
+
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from drf_spectacular.types import OpenApiTypes
 from rest_framework.viewsets import GenericViewSet
 from rest_framework import mixins, status
 from rest_framework.response import Response
 from rest_framework.decorators import action
+from django.db import transaction
 from django.utils import timezone
 from sequence_run_manager.models import State, Sequence
 from sequence_run_manager.serializers.state import StateSerializer, StateCreateRequestSerializer, StateUpdateRequestSerializer
+
+logger = logging.getLogger(__name__)
 
 @extend_schema_view(
     create=extend_schema(
@@ -88,22 +93,23 @@ class StateViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, mixins.List
             if not self._validate_state_status(latest_status, request_status):
                 return Response({"detail": "Invalid state request. Can't add state '{}' to '{}'".format(request_status, latest_status)},
                                 status=status.HTTP_400_BAD_REQUEST)
-        # create state
+        # create state and sync sequence status atomically
         try:
-            instance = State.objects.create(
-                sequence=sequence,
-                status=request_status,
-                timestamp=timezone.now(),
-                comment=request_comment,
-            )
-        except Exception as e:
-            return Response({"detail": "Failed to create state. Error: {}".format(str(e))},
+            with transaction.atomic():
+                instance = State.objects.create(
+                    sequence=sequence,
+                    status=request_status,
+                    timestamp=timezone.now(),
+                    comment=request_comment,
+                )
+                # update sequence status if the new state is in states_transition_validation_map
+                if request_status in self.states_transition_validation_map:
+                    sequence.status = request_status
+                    sequence.save(update_fields=["status"])
+        except Exception:
+            logger.exception("Failed to create state for sequence %s", sequence_orcabus_id)
+            return Response({"detail": "Failed to create state. Please try again later."},
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-        # update sequence status if the new state is in states_transition_validation_map
-        if request_status in self.states_transition_validation_map:
-            sequence.status = request_status
-            sequence.save(update_fields=["status"])
 
         data = StateSerializer(instance).data
         headers = self.get_success_headers(data)


### PR DESCRIPTION
## Fix: Sync sequence run status when creating RESOLVED/DEPRECATED state

### Problem

Issue come from previous PR [refactor api params for sequence run](https://github.com/OrcaBus/service-sequence-run-manager/pull/53/changes#top), which remove the code for Sync sequence run status when creating RESOLVED/DEPRECATED state, refer code [here](https://github.com/OrcaBus/service-sequence-run-manager/pull/53/changes#diff-9b2b2e7e6d6095555aaad5573be1df155c8a27842e89be6ca69f43107852e0f6L62).

The issue is when a state of [RESOLVED]or [DEPRECATED]was created for a sequence run, the parent [Sequence.status] field was not being updated. This left the sequence's status stale, out of sync with its latest state.

See UI issue for instrument run of `260320_A01052_0303_BHTY3VDSXF`: https://portal.umccr.org/sequence/260320_A01052_0303_BHTY3VDSXF/details
### Changes
- viewsets/state.py

After successfully creating a [RESOLVED]or [DEPRECATED] state, the parent sequence's status field is now updated to match, using update_fields for an efficient partial save.
Wrapped `State.objects.create()` in a try/except to return a structured HTTP 500 response if the DB write fails, rather than letting an unhandled exception propagate.

- tests/test_viewsets.py

test_create_state_resolved_after_failed after the API call.
test_create_state_deprecated_after_succeeded after the API call.
