### PR TITLE
emit srsc event for state transition api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ fix:
 	@pnpm lint-fix
 
 audit-fix:
-	@pnpm audit --fix
+	@pnpm audit --fix override
 
 install:
 	@pnpm install --frozen-lockfile

--- a/app/sequence_run_manager/aws_event_bridge/event_srv.py
+++ b/app/sequence_run_manager/aws_event_bridge/event_srv.py
@@ -4,16 +4,133 @@ from django.utils import timezone
 from libumccr.aws import libeb
 from sequence_run_manager_proc.domain.samplesheet import SampleSheetDomain
 from sequence_run_manager_proc.domain.librarylinking import LibraryLinkingDomain
+from sequence_run_manager_proc.domain.events.srsc import SequenceRunStateChange
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+SRSC_EVENT_TYPE = SequenceRunStateChange.__name__
+SRSSC_EVENT_TYPE = "SequenceRunSampleSheetChange"
+SRLLC_EVENT_TYPE = "SequenceRunLibraryLinkingChange"
+SRM_SOURCE = "orcabus.sequencerunmanager"
 
-def emit_srm_api_event(event):
+
+class EventBridgePublishError(RuntimeError):
+    """Raised when EventBridge accepts a request but rejects its event entry."""
+
+    def __init__(self, message: str, failed_entries: list[dict] | None = None):
+        super().__init__(message)
+        self.failed_entries = failed_entries or []
+
+
+def _get_event_bus_name():
+    event_bus_name = os.environ.get("EVENT_BUS_NAME", None)
+    if event_bus_name is None:
+        logger.error("EVENT_BUS_NAME is not set")
+    return event_bus_name
+
+
+def _event_type_is_valid(event: dict, expected_event_type: str) -> bool:
+    event_type = event.get("eventType")
+    if event_type != expected_event_type:
+        logger.error(f"Unsupported event type: {event_type}")
+        return False
+    return True
+
+
+def _emit_api_event(event_type: str, event_entry: dict, event_bus_name: str):
+    try:
+        response = libeb.emit_event(event_entry)
+        logger.info(
+            f"Sent a {event_type} event to event bus {event_bus_name}: {event_entry}"
+        )
+        return response
+    except Exception as e:
+        logger.error(f"Failed to emit {event_type} event: {e}")
+        return
+
+
+def emit_srsc_api_event(event: dict, attempt_count: int = 1):
+    """Validate and emit a SequenceRunStateChange created through the API."""
+    event_id = event.get("id", "unknown")
+    instrument_run_id = event.get("instrumentRunId", "unknown")
+    event_status = event.get("status", "unknown")
+
+    try:
+        event_bus_name = os.environ.get("EVENT_BUS_NAME", None)
+        if event_bus_name is None:
+            raise ValueError("EVENT_BUS_NAME environment variable is not set.")
+
+        validated = SequenceRunStateChange.model_validate(event)
+        detail_json = validated.model_dump_json()
+        event_id = validated.id
+        instrument_run_id = validated.instrumentRunId
+        event_status = validated.status
+
+        logger.info(
+            "Emitting SRSC event: event_id=%s instrument_run_id=%s status=%s attempt=%s",
+            event_id,
+            instrument_run_id,
+            event_status,
+            attempt_count,
+        )
+        response = libeb.emit_event(
+            {
+                "Source": SRM_SOURCE,
+                "DetailType": SRSC_EVENT_TYPE,
+                "Detail": detail_json,
+                "EventBusName": event_bus_name,
+            }
+        )
+
+        failed_entry_count = response.get("FailedEntryCount", 0)
+        if failed_entry_count:
+            failed_entries = [
+                {
+                    "error_code": entry.get("ErrorCode"),
+                    "error_message": entry.get("ErrorMessage"),
+                }
+                for entry in response.get("Entries", [])
+                if entry.get("ErrorCode") or entry.get("ErrorMessage")
+            ]
+            logger.error(
+                "EventBridge rejected SRSC event entry: event_id=%s instrument_run_id=%s status=%s attempt=%s failed_entry_count=%s failed_entries=%s",
+                event_id,
+                instrument_run_id,
+                event_status,
+                attempt_count,
+                failed_entry_count,
+                failed_entries,
+            )
+            raise EventBridgePublishError(
+                f"EventBridge rejected {failed_entry_count} SRSC event entry: {failed_entries}",
+                failed_entries=failed_entries,
+            )
+
+        logger.info(
+            "SRSC event emitted: event_id=%s instrument_run_id=%s status=%s attempt=%s",
+            event_id,
+            instrument_run_id,
+            event_status,
+            attempt_count,
+        )
+        return response
+    except Exception:
+        logger.exception(
+            "Failed to emit SRSC event: event_id=%s instrument_run_id=%s status=%s attempt=%s",
+            event_id,
+            instrument_run_id,
+            event_status,
+            attempt_count,
+        )
+        raise
+
+
+def emit_srssc_api_event(event):
     """
-    Emit events to the event bridge sourced from the sequence run manager API
+    Emit SRSSC events to the event bridge sourced from the sequence run manager API.
 
-    so far we only support SRSSC and SRLLC events, examples:
+    Example:
     {
     "version": "0",
     "id": "12345678-90ab-cdef-1234-567890abcdef",
@@ -36,6 +153,33 @@ def emit_srm_api_event(event):
         }
         }
     }
+    """
+
+    event_bus_name = _get_event_bus_name()
+    if event_bus_name is None:
+        return
+
+    if not _event_type_is_valid(event, SRSSC_EVENT_TYPE):
+        return
+
+    sample_sheet_domain = SampleSheetDomain(
+        instrument_run_id=event["instrumentRunId"],
+        sequence_run_id=event["sequenceRunId"],
+        sample_sheet=event["sampleSheet"],
+        description=event["description"],
+    )
+    event_entry = sample_sheet_domain.to_put_events_request_entry(
+        event_bus_name=event_bus_name,
+    )
+
+    return _emit_api_event(SRSSC_EVENT_TYPE, event_entry, event_bus_name)
+
+
+def emit_srllc_api_event(event):
+    """
+    Emit SRLLC events to the event bridge sourced from the sequence run manager API.
+
+    Example:
     {
     "version": "0",
     "id": "12345678-90ab-cdef-1234-567890abcdef",
@@ -56,66 +200,23 @@ def emit_srm_api_event(event):
             ],
         }
     }
-
     """
 
-    # construct event
-    supported_event_types = [
-        "SequenceRunSampleSheetChange",
-        "SequenceRunLibraryLinkingChange",
-    ]
-    event_bus_name = os.environ.get("EVENT_BUS_NAME", None)
-
+    event_bus_name = _get_event_bus_name()
     if event_bus_name is None:
-        logger.error("EVENT_BUS_NAME is not set")
         return
 
-    event_type = event["eventType"]
-    if event_type not in supported_event_types:
-        logger.error(f"Unsupported event type: {event_type}")
+    if not _event_type_is_valid(event, SRLLC_EVENT_TYPE):
         return
 
-    event_entry = None
-    match event_type:
-        case "SequenceRunSampleSheetChange":
-            sample_sheet_domain = SampleSheetDomain(
-                instrument_run_id=event["instrumentRunId"],
-                sequence_run_id=event["sequenceRunId"],
-                sample_sheet=event["sampleSheet"],
-                description=event["description"],
-            )
-            event_entry = sample_sheet_domain.to_put_events_request_entry(
-                event_bus_name=event_bus_name,
-            )
+    library_linking_domain = LibraryLinkingDomain(
+        instrument_run_id=event["instrumentRunId"],
+        sequence_run_id=event["sequenceRunId"],
+        linked_libraries=event["linkedLibraries"],
+        timestamp=(event["timeStamp"] if "timeStamp" in event else timezone.now()),
+    )
+    event_entry = library_linking_domain.to_put_events_request_entry(
+        event_bus_name=event_bus_name,
+    )
 
-        case "SequenceRunLibraryLinkingChange":
-            library_linking_domain = LibraryLinkingDomain(
-                instrument_run_id=event["instrumentRunId"],
-                sequence_run_id=event["sequenceRunId"],
-                linked_libraries=event["linkedLibraries"],
-                timestamp=(
-                    event["timeStamp"] if "timeStamp" in event else timezone.now()
-                ),
-            )
-            event_entry = library_linking_domain.to_put_events_request_entry(
-                event_bus_name=event_bus_name,
-            )
-
-        case _:
-            logger.error(f"Unsupported event type: {event['eventType']}")
-            return
-
-    # emit event
-    if event_entry is not None:
-        try:
-            response = libeb.emit_event(event_entry)
-            logger.info(
-                f"Sent a {event_type} event to event bus {event_bus_name}: {event_entry}"
-            )
-            return response
-        except Exception as e:
-            logger.error(f"Failed to emit event: {e}")
-            return
-    else:
-        logger.error(f"Failed to construct event entry for {event_type}")
-        return
+    return _emit_api_event(SRLLC_EVENT_TYPE, event_entry, event_bus_name)

--- a/app/sequence_run_manager/tests/test_event_bridge.py
+++ b/app/sequence_run_manager/tests/test_event_bridge.py
@@ -1,0 +1,84 @@
+import json
+import os
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from sequence_run_manager.aws_event_bridge.event_srv import (
+    EventBridgePublishError,
+    emit_srsc_api_event,
+)
+
+
+class SrscApiEventTestCase(SimpleTestCase):
+    def build_event(self):
+        return {
+            "id": "seq.01J5M2JFE1JPYV62RYQEG99SEQ",
+            "instrumentRunId": "250328_A01052_0258_AHFGM7DSXF",
+            "runVolumeName": "bssh.example",
+            "runFolderPath": "/Runs/250328_A01052_0258_AHFGM7DSXF",
+            "runDataUri": "gds://bssh.example/Runs/250328_A01052_0258_AHFGM7DSXF",
+            "sampleSheetName": None,
+            "startTime": timezone.now().isoformat(),
+            "endTime": None,
+            "status": "RESOLVED",
+        }
+
+    @patch.dict(os.environ, {"EVENT_BUS_NAME": "test-event-bus"})
+    @patch("sequence_run_manager.aws_event_bridge.event_srv.libeb.emit_event")
+    def test_emit_srsc_api_event_emits_sequence_run_state_change(
+        self, mock_emit_event
+    ):
+        mock_emit_event.return_value = {"FailedEntryCount": 0, "Entries": [{}]}
+
+        emit_srsc_api_event(self.build_event(), attempt_count=2)
+
+        entry = mock_emit_event.call_args.args[0]
+        self.assertEqual(entry["Source"], "orcabus.sequencerunmanager")
+        self.assertEqual(entry["DetailType"], "SequenceRunStateChange")
+        self.assertEqual(entry["EventBusName"], "test-event-bus")
+        detail = json.loads(entry["Detail"])
+        self.assertEqual(detail["status"], "RESOLVED")
+        self.assertIn("sampleSheetName", detail)
+        self.assertIsNone(detail["sampleSheetName"])
+
+    @patch.dict(os.environ, {"EVENT_BUS_NAME": "test-event-bus"})
+    @patch("sequence_run_manager.aws_event_bridge.event_srv.libeb.emit_event")
+    def test_emit_srsc_api_event_raises_and_logs_partial_failure(
+        self, mock_emit_event
+    ):
+        mock_emit_event.return_value = {
+            "FailedEntryCount": 1,
+            "Entries": [
+                {
+                    "ErrorCode": "InternalFailure",
+                    "ErrorMessage": "EventBridge failed",
+                }
+            ],
+        }
+
+        with self.assertLogs(
+            "sequence_run_manager.aws_event_bridge.event_srv", level="ERROR"
+        ) as logs:
+            with self.assertRaises(EventBridgePublishError):
+                emit_srsc_api_event(self.build_event())
+
+        logged = " ".join(logs.output)
+        self.assertIn("seq.01J5M2JFE1JPYV62RYQEG99SEQ", logged)
+        self.assertIn("InternalFailure", logged)
+
+    @patch.dict(os.environ, {"EVENT_BUS_NAME": "test-event-bus"})
+    @patch("sequence_run_manager.aws_event_bridge.event_srv.libeb.emit_event")
+    def test_emit_srsc_api_event_reraises_sdk_exception(self, mock_emit_event):
+        mock_emit_event.side_effect = RuntimeError("network unavailable")
+
+        with self.assertLogs(
+            "sequence_run_manager.aws_event_bridge.event_srv", level="ERROR"
+        ) as logs:
+            with self.assertRaisesRegex(RuntimeError, "network unavailable"):
+                emit_srsc_api_event(self.build_event(), attempt_count=3)
+
+        logged = " ".join(logs.output)
+        self.assertIn("seq.01J5M2JFE1JPYV62RYQEG99SEQ", logged)
+        self.assertIn("attempt=3", logged)

--- a/app/sequence_run_manager/tests/test_event_bridge.py
+++ b/app/sequence_run_manager/tests/test_event_bridge.py
@@ -7,8 +7,11 @@ from django.utils import timezone
 
 from sequence_run_manager.aws_event_bridge.event_srv import (
     EventBridgePublishError,
+    emit_srllc_api_event,
     emit_srsc_api_event,
+    emit_srssc_api_event,
 )
+from sequence_run_manager.models.sample_sheet import SampleSheet
 
 
 class SrscApiEventTestCase(SimpleTestCase):
@@ -82,3 +85,162 @@ class SrscApiEventTestCase(SimpleTestCase):
         logged = " ".join(logs.output)
         self.assertIn("seq.01J5M2JFE1JPYV62RYQEG99SEQ", logged)
         self.assertIn("attempt=3", logged)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_emit_srsc_api_event_raises_when_event_bus_is_missing(self):
+        with self.assertLogs(
+            "sequence_run_manager.aws_event_bridge.event_srv", level="ERROR"
+        ) as logs:
+            with self.assertRaisesRegex(ValueError, "EVENT_BUS_NAME"):
+                emit_srsc_api_event(self.build_event())
+
+        logged = " ".join(logs.output)
+        self.assertIn("seq.01J5M2JFE1JPYV62RYQEG99SEQ", logged)
+
+
+class SrsscApiEventTestCase(SimpleTestCase):
+    def build_event(self, event_type="SequenceRunSampleSheetChange"):
+        sample_sheet = SampleSheet(
+            orcabus_id="ss.01J5M2JFE1JPYV62RYQEG99SS",
+            sample_sheet_name="SampleSheet.csv",
+            sample_sheet_content_original="sample,sheet\n",
+            association_timestamp=timezone.now(),
+        )
+        return {
+            "eventType": event_type,
+            "instrumentRunId": "250328_A01052_0258_AHFGM7DSXF",
+            "sequenceRunId": "r.01J5M2JFE1JPYV62RYQEG99RUN",
+            "sampleSheet": sample_sheet,
+            "description": "Manual sample sheet update",
+        }
+
+    @patch.dict(
+        os.environ,
+        {
+            "EVENT_BUS_NAME": "test-event-bus",
+            "SEQUENCE_RUN_MANAGER_BASE_API_URL": "https://srm.example",
+        },
+    )
+    @patch("sequence_run_manager.aws_event_bridge.event_srv.libeb.emit_event")
+    def test_emit_srssc_api_event_emits_sample_sheet_change(self, mock_emit_event):
+        mock_emit_event.return_value = {"FailedEntryCount": 0, "Entries": [{}]}
+
+        response = emit_srssc_api_event(self.build_event())
+
+        self.assertEqual(response, {"FailedEntryCount": 0, "Entries": [{}]})
+        entry = mock_emit_event.call_args.args[0]
+        self.assertEqual(entry["DetailType"], "SequenceRunSampleSheetChange")
+        self.assertEqual(entry["EventBusName"], "test-event-bus")
+        detail = json.loads(entry["Detail"])
+        self.assertEqual(detail["instrumentRunId"], "250328_A01052_0258_AHFGM7DSXF")
+        self.assertEqual(detail["sampleSheetName"], "SampleSheet.csv")
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("sequence_run_manager.aws_event_bridge.event_srv.libeb.emit_event")
+    def test_emit_srssc_api_event_returns_when_event_bus_is_missing(
+        self, mock_emit_event
+    ):
+        with self.assertLogs(
+            "sequence_run_manager.aws_event_bridge.event_srv", level="ERROR"
+        ) as logs:
+            response = emit_srssc_api_event(self.build_event())
+
+        self.assertIsNone(response)
+        mock_emit_event.assert_not_called()
+        self.assertIn("EVENT_BUS_NAME is not set", " ".join(logs.output))
+
+    @patch.dict(os.environ, {"EVENT_BUS_NAME": "test-event-bus"})
+    @patch("sequence_run_manager.aws_event_bridge.event_srv.libeb.emit_event")
+    def test_emit_srssc_api_event_returns_for_wrong_event_type(
+        self, mock_emit_event
+    ):
+        with self.assertLogs(
+            "sequence_run_manager.aws_event_bridge.event_srv", level="ERROR"
+        ) as logs:
+            response = emit_srssc_api_event(
+                self.build_event(event_type="SequenceRunLibraryLinkingChange")
+            )
+
+        self.assertIsNone(response)
+        mock_emit_event.assert_not_called()
+        self.assertIn("Unsupported event type", " ".join(logs.output))
+
+    @patch.dict(
+        os.environ,
+        {
+            "EVENT_BUS_NAME": "test-event-bus",
+            "SEQUENCE_RUN_MANAGER_BASE_API_URL": "https://srm.example",
+        },
+    )
+    @patch("sequence_run_manager.aws_event_bridge.event_srv.libeb.emit_event")
+    def test_emit_srssc_api_event_logs_and_returns_on_emit_exception(
+        self, mock_emit_event
+    ):
+        mock_emit_event.side_effect = RuntimeError("event bus unavailable")
+
+        with self.assertLogs(
+            "sequence_run_manager.aws_event_bridge.event_srv", level="ERROR"
+        ) as logs:
+            response = emit_srssc_api_event(self.build_event())
+
+        self.assertIsNone(response)
+        self.assertIn(
+            "Failed to emit SequenceRunSampleSheetChange", " ".join(logs.output)
+        )
+
+
+class SrllcApiEventTestCase(SimpleTestCase):
+    def build_event(self, event_type="SequenceRunLibraryLinkingChange"):
+        return {
+            "eventType": event_type,
+            "instrumentRunId": "250328_A01052_0258_AHFGM7DSXF",
+            "sequenceRunId": "r.01J5M2JFE1JPYV62RYQEG99RUN",
+            "linkedLibraries": ["L2000001", "L2000002"],
+        }
+
+    @patch.dict(os.environ, {"EVENT_BUS_NAME": "test-event-bus"})
+    @patch("sequence_run_manager.aws_event_bridge.event_srv.libeb.emit_event")
+    def test_emit_srllc_api_event_emits_library_linking_change(
+        self, mock_emit_event
+    ):
+        mock_emit_event.return_value = {"FailedEntryCount": 0, "Entries": [{}]}
+
+        response = emit_srllc_api_event(self.build_event())
+
+        self.assertEqual(response, {"FailedEntryCount": 0, "Entries": [{}]})
+        entry = mock_emit_event.call_args.args[0]
+        self.assertEqual(entry["DetailType"], "SequenceRunLibraryLinkingChange")
+        self.assertEqual(entry["EventBusName"], "test-event-bus")
+        detail = json.loads(entry["Detail"])
+        self.assertEqual(detail["instrumentRunId"], "250328_A01052_0258_AHFGM7DSXF")
+        self.assertEqual(detail["linkedLibraries"], ["L2000001", "L2000002"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("sequence_run_manager.aws_event_bridge.event_srv.libeb.emit_event")
+    def test_emit_srllc_api_event_returns_when_event_bus_is_missing(
+        self, mock_emit_event
+    ):
+        with self.assertLogs(
+            "sequence_run_manager.aws_event_bridge.event_srv", level="ERROR"
+        ) as logs:
+            response = emit_srllc_api_event(self.build_event())
+
+        self.assertIsNone(response)
+        mock_emit_event.assert_not_called()
+        self.assertIn("EVENT_BUS_NAME is not set", " ".join(logs.output))
+
+    @patch.dict(os.environ, {"EVENT_BUS_NAME": "test-event-bus"})
+    @patch("sequence_run_manager.aws_event_bridge.event_srv.libeb.emit_event")
+    def test_emit_srllc_api_event_returns_for_wrong_event_type(
+        self, mock_emit_event
+    ):
+        with self.assertLogs(
+            "sequence_run_manager.aws_event_bridge.event_srv", level="ERROR"
+        ) as logs:
+            response = emit_srllc_api_event(
+                self.build_event(event_type="SequenceRunSampleSheetChange")
+            )
+
+        self.assertIsNone(response)
+        mock_emit_event.assert_not_called()
+        self.assertIn("Unsupported event type", " ".join(logs.output))

--- a/app/sequence_run_manager/tests/test_viewsets.py
+++ b/app/sequence_run_manager/tests/test_viewsets.py
@@ -1,11 +1,12 @@
 import logging
 from pathlib import Path
-from unittest.mock import patch
+from threading import Barrier, Thread
+from unittest.mock import Mock, patch
 import base64
 import json
 
-from django.db import DatabaseError
-from django.test import TestCase
+from django.db import DatabaseError, close_old_connections
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils.timezone import now
 from datetime import timedelta
@@ -546,12 +547,47 @@ class SequenceViewSetTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
+    def test_create_state_revalidates_locked_sequence_status(
+        self, mock_emit_srsc_event
+    ):
+        sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
+        sequence_run.status = SequenceStatus.FAILED
+        sequence_run.save(update_fields=["status"])
+
+        locked_sequence = Sequence.objects.get(pk=sequence_run.pk)
+        locked_sequence.status = SequenceStatus.RESOLVED
+        locked_queryset = Mock()
+        locked_queryset.get.return_value = locked_sequence
+
+        with patch.object(
+            Sequence.objects,
+            "select_for_update",
+            return_value=locked_queryset,
+        ) as mock_select_for_update:
+            with self.assertLogs(
+                "sequence_run_manager.viewsets.state", level="WARNING"
+            ) as logs:
+                response = self.client.post(
+                    f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
+                    {"status": "RESOLVED", "comment": "Handled"},
+                    format="json",
+                )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("concurrent_update=true", " ".join(logs.output))
+        self.assertFalse(
+            State.objects.filter(sequence=sequence_run, status="RESOLVED").exists()
+        )
+        mock_select_for_update.assert_called_once_with()
+        mock_emit_srsc_event.assert_not_called()
+
     @patch(
-        "sequence_run_manager.viewsets.state.StateViewSet.create_state_and_emit_srsc",
+        "sequence_run_manager.viewsets.state.StateViewSet.create_state_and_build_srsc",
         side_effect=DatabaseError("database unavailable"),
     )
     def test_create_state_database_failure_returns_error_and_rolls_back_state(
-        self, mock_create_state_and_emit_srsc
+        self, mock_create_state_and_build_srsc
     ):
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
         sequence_run.status = SequenceStatus.FAILED
@@ -575,7 +611,7 @@ class SequenceViewSetTestCase(TestCase):
         self.assertFalse(
             State.objects.filter(sequence=sequence_run, status="RESOLVED").exists()
         )
-        mock_create_state_and_emit_srsc.assert_called_once()
+        mock_create_state_and_build_srsc.assert_called_once()
 
     @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
     def test_create_state_resolved_after_failed(self, mock_emit_srsc_event):
@@ -588,11 +624,12 @@ class SequenceViewSetTestCase(TestCase):
             timestamp=now(),
             comment="stale detail status",
         )
-        response = self.client.post(
-            f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
-            {"status": "RESOLVED", "comment": "Handled"},
-            format="json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
+                {"status": "RESOLVED", "comment": "Handled"},
+                format="json",
+            )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["status"], "RESOLVED")
         self.assertEqual(response.data["comment"], "Handled")
@@ -605,15 +642,11 @@ class SequenceViewSetTestCase(TestCase):
         mock_emit_srsc_event.assert_called_once()
         srsc_event = mock_emit_srsc_event.call_args.args[0]
         self.assertEqual(srsc_event["id"], sequence_run.orcabus_id)
-        self.assertEqual(
-            srsc_event["instrumentRunId"], sequence_run.instrument_run_id
-        )
+        self.assertEqual(srsc_event["instrumentRunId"], sequence_run.instrument_run_id)
         self.assertEqual(srsc_event["runVolumeName"], sequence_run.run_volume_name)
         self.assertEqual(srsc_event["runFolderPath"], sequence_run.run_folder_path)
         self.assertEqual(srsc_event["runDataUri"], sequence_run.run_data_uri)
-        self.assertEqual(
-            srsc_event["sampleSheetName"], sequence_run.sample_sheet_name
-        )
+        self.assertEqual(srsc_event["sampleSheetName"], sequence_run.sample_sheet_name)
         self.assertEqual(srsc_event["status"], "RESOLVED")
 
     @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
@@ -625,11 +658,12 @@ class SequenceViewSetTestCase(TestCase):
             timestamp=now(),
             comment="stale detail status",
         )
-        response = self.client.post(
-            f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
-            {"status": "DEPRECATED", "comment": "No longer used"},
-            format="json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
+                {"status": "DEPRECATED", "comment": "No longer used"},
+                format="json",
+            )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["status"], "DEPRECATED")
         sequence_run.refresh_from_db()
@@ -644,7 +678,7 @@ class SequenceViewSetTestCase(TestCase):
         self.assertEqual(srsc_event["status"], "DEPRECATED")
 
     @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
-    def test_create_state_publish_failure_returns_error_and_rolls_back_state(
+    def test_create_state_publish_failure_is_logged_after_commit(
         self, mock_emit_srsc_event
     ):
         mock_emit_srsc_event.side_effect = RuntimeError("event bus unavailable")
@@ -657,18 +691,46 @@ class SequenceViewSetTestCase(TestCase):
             timestamp=now(),
             comment="failed",
         )
-        response = self.client.post(
-            f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
-            {"status": "RESOLVED", "comment": "Handled"},
-            format="json",
-        )
-        self.assertEqual(response.status_code, 502)
-        self.assertIn("rolled back", response.data["detail"])
-        self.assertFalse(
-            State.objects.filter(sequence=sequence_run, status="RESOLVED").exists()
-        )
+        with self.assertLogs(
+            "sequence_run_manager.viewsets.state", level="ERROR"
+        ) as logs:
+            with self.captureOnCommitCallbacks(execute=True):
+                response = self.client.post(
+                    f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
+                    {"status": "RESOLVED", "comment": "Handled"},
+                    format="json",
+                )
+
+        self.assertEqual(response.status_code, 201)
+        state = State.objects.get(sequence=sequence_run, status="RESOLVED")
         sequence_run.refresh_from_db()
-        self.assertEqual(sequence_run.status, "FAILED")
+        self.assertEqual(sequence_run.status, "RESOLVED")
+        mock_emit_srsc_event.assert_called_once()
+        logged = " ".join(logs.output)
+        self.assertIn("failed after database commit", logged)
+        self.assertIn(str(sequence_run.orcabus_id), logged)
+        self.assertIn(str(state.orcabus_id), logged)
+        self.assertIn("recoverable=true", logged)
+
+    @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
+    def test_create_state_defers_srsc_publication_until_commit(
+        self, mock_emit_srsc_event
+    ):
+        sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
+        sequence_run.status = SequenceStatus.FAILED
+        sequence_run.save(update_fields=["status"])
+
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            response = self.client.post(
+                f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
+                {"status": "RESOLVED", "comment": "Handled"},
+                format="json",
+            )
+            mock_emit_srsc_event.assert_not_called()
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(len(callbacks), 1)
+        callbacks[0]()
         mock_emit_srsc_event.assert_called_once()
 
     @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
@@ -697,11 +759,12 @@ class SequenceViewSetTestCase(TestCase):
         )
         self.assertEqual(bad.status_code, 400)
         mock_emit_srsc_event.assert_not_called()
-        good = self.client.post(
-            f"{self.sequence_run_endpoint}/{orphan.orcabus_id}/state/",
-            {"status": "DEPRECATED", "comment": "initial"},
-            format="json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            good = self.client.post(
+                f"{self.sequence_run_endpoint}/{orphan.orcabus_id}/state/",
+                {"status": "DEPRECATED", "comment": "initial"},
+                format="json",
+            )
         self.assertEqual(good.status_code, 201)
         self.assertEqual(good.data["status"], "DEPRECATED")
         mock_emit_srsc_event.assert_called_once()
@@ -711,9 +774,7 @@ class SequenceViewSetTestCase(TestCase):
 
     @patch("sequence_run_manager.viewsets.sequence_run_action.emit_srllc_api_event")
     @patch("sequence_run_manager.viewsets.sequence_run_action.emit_srssc_api_event")
-    def test_add_samplesheet_action(
-        self, mock_emit_srssc_event, mock_emit_srllc_event
-    ):
+    def test_add_samplesheet_action(self, mock_emit_srssc_event, mock_emit_srllc_event):
         """
         python manage.py test sequence_run_manager.tests.test_viewsets.SequenceViewSetTestCase.test_add_samplesheet_action
         """
@@ -860,3 +921,74 @@ class SequenceViewSetTestCase(TestCase):
         self.assertEqual(
             len(get_samplesheet_checksum_response.data), 1, "One result is expected"
         )
+
+
+@skipUnlessDBFeature("has_select_for_update")
+class StateTransitionConcurrencyTestCase(TransactionTestCase):
+    """Exercise real row-lock behavior using separate database connections."""
+
+    reset_sequences = True
+    sequence_run_endpoint = f"/{api_base}sequence_run"
+
+    def setUp(self):
+        self.sequence = Sequence.objects.create(
+            instrument_run_id="concurrent_run_001",
+            run_volume_name="vol",
+            run_folder_path="/runs/concurrent_run_001",
+            run_data_uri="gds://vol/runs/concurrent_run_001",
+            status=SequenceStatus.FAILED,
+            start_time=now(),
+            sample_sheet_name="SampleSheet.csv",
+            sequence_run_id="r.CONCURRENT01",
+            sequence_run_name="concurrent_run_001",
+            api_url="https://bssh.dev/api/v1/runs/r.CONCURRENT01",
+        )
+
+    @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
+    def test_competing_resolved_transitions_create_one_state(
+        self, mock_emit_srsc_event
+    ):
+        initial_read_barrier = Barrier(2)
+        original_get = Sequence.objects.get
+        responses = []
+        errors = []
+
+        def synchronized_initial_get(*args, **kwargs):
+            sequence = original_get(*args, **kwargs)
+            initial_read_barrier.wait(timeout=5)
+            return sequence
+
+        def post_transition():
+            close_old_connections()
+            try:
+                client = APIClient()
+                response = client.post(
+                    f"{self.sequence_run_endpoint}/{self.sequence.orcabus_id}/state/",
+                    {"status": "RESOLVED", "comment": "Handled"},
+                    format="json",
+                )
+                responses.append(response.status_code)
+            except Exception as exc:
+                errors.append(exc)
+            finally:
+                close_old_connections()
+
+        with patch.object(
+            Sequence.objects,
+            "get",
+            side_effect=synchronized_initial_get,
+        ):
+            threads = [Thread(target=post_transition) for _ in range(2)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=10)
+
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(errors, [])
+        self.assertEqual(sorted(responses), [201, 400])
+        self.assertEqual(
+            State.objects.filter(sequence=self.sequence, status="RESOLVED").count(),
+            1,
+        )
+        mock_emit_srsc_event.assert_called_once()

--- a/app/sequence_run_manager/tests/test_viewsets.py
+++ b/app/sequence_run_manager/tests/test_viewsets.py
@@ -531,11 +531,17 @@ class SequenceViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_create_state_invalid_transition(self):
-        """Latest state is Complete (setUp); RESOLVED is only allowed after FAILED."""
+        """Sequence status wins even when the latest state allows the transition."""
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
+        State.objects.create(
+            sequence=sequence_run,
+            status="FAILED",
+            timestamp=now(),
+            comment="failed",
+        )
         response = self.client.post(
             f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
-            {"status": "RESOLVED", "comment": "Cannot from Complete"},
+            {"status": "RESOLVED", "comment": "Cannot from SUCCEEDED"},
             format="json",
         )
         self.assertEqual(response.status_code, 400)
@@ -548,6 +554,8 @@ class SequenceViewSetTestCase(TestCase):
         self, mock_create_state_and_emit_srsc
     ):
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
+        sequence_run.status = SequenceStatus.FAILED
+        sequence_run.save(update_fields=["status"])
         State.objects.create(
             sequence=sequence_run,
             status="FAILED",
@@ -572,11 +580,13 @@ class SequenceViewSetTestCase(TestCase):
     @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
     def test_create_state_resolved_after_failed(self, mock_emit_srsc_event):
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
+        sequence_run.status = SequenceStatus.FAILED
+        sequence_run.save(update_fields=["status"])
         State.objects.create(
             sequence=sequence_run,
-            status="FAILED",
+            status="SUCCEEDED",
             timestamp=now(),
-            comment="failed",
+            comment="stale detail status",
         )
         response = self.client.post(
             f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
@@ -611,9 +621,9 @@ class SequenceViewSetTestCase(TestCase):
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
         State.objects.create(
             sequence=sequence_run,
-            status="SUCCEEDED",
+            status="FAILED",
             timestamp=now(),
-            comment="ok",
+            comment="stale detail status",
         )
         response = self.client.post(
             f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
@@ -639,6 +649,8 @@ class SequenceViewSetTestCase(TestCase):
     ):
         mock_emit_srsc_event.side_effect = RuntimeError("event bus unavailable")
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
+        sequence_run.status = SequenceStatus.FAILED
+        sequence_run.save(update_fields=["status"])
         State.objects.create(
             sequence=sequence_run,
             status="FAILED",
@@ -656,11 +668,11 @@ class SequenceViewSetTestCase(TestCase):
             State.objects.filter(sequence=sequence_run, status="RESOLVED").exists()
         )
         sequence_run.refresh_from_db()
-        self.assertEqual(sequence_run.status, "SUCCEEDED")
+        self.assertEqual(sequence_run.status, "FAILED")
         mock_emit_srsc_event.assert_called_once()
 
     @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
-    def test_create_state_only_deprecated_when_no_prior_states(
+    def test_create_state_only_deprecated_when_no_current_sequence_status(
         self, mock_emit_srsc_event
     ):
         orphan = Sequence.objects.create(
@@ -668,7 +680,7 @@ class SequenceViewSetTestCase(TestCase):
             run_volume_name="vol",
             run_folder_path="/p",
             run_data_uri="gds://vol/p",
-            status=SequenceStatus.from_seq_run_status("Complete"),
+            status=None,
             start_time=now(),
             sample_sheet_name="SampleSheet.csv",
             sequence_run_id="r.ORPHAN01",

--- a/app/sequence_run_manager/tests/test_viewsets.py
+++ b/app/sequence_run_manager/tests/test_viewsets.py
@@ -491,7 +491,8 @@ class SequenceViewSetTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 400)
 
-    def test_create_state_resolved_after_failed(self):
+    @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
+    def test_create_state_resolved_after_failed(self, mock_emit_srsc_event):
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
         State.objects.create(
             sequence=sequence_run,
@@ -513,8 +514,22 @@ class SequenceViewSetTestCase(TestCase):
             "RESOLVED",
             "Sequence status should be updated to RESOLVED",
         )
+        mock_emit_srsc_event.assert_called_once()
+        srsc_event = mock_emit_srsc_event.call_args.args[0]
+        self.assertEqual(srsc_event["id"], sequence_run.orcabus_id)
+        self.assertEqual(
+            srsc_event["instrumentRunId"], sequence_run.instrument_run_id
+        )
+        self.assertEqual(srsc_event["runVolumeName"], sequence_run.run_volume_name)
+        self.assertEqual(srsc_event["runFolderPath"], sequence_run.run_folder_path)
+        self.assertEqual(srsc_event["runDataUri"], sequence_run.run_data_uri)
+        self.assertEqual(
+            srsc_event["sampleSheetName"], sequence_run.sample_sheet_name
+        )
+        self.assertEqual(srsc_event["status"], "RESOLVED")
 
-    def test_create_state_deprecated_after_succeeded(self):
+    @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
+    def test_create_state_deprecated_after_succeeded(self, mock_emit_srsc_event):
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
         State.objects.create(
             sequence=sequence_run,
@@ -535,8 +550,41 @@ class SequenceViewSetTestCase(TestCase):
             "DEPRECATED",
             "Sequence status should be updated to DEPRECATED",
         )
+        mock_emit_srsc_event.assert_called_once()
+        srsc_event = mock_emit_srsc_event.call_args.args[0]
+        self.assertEqual(srsc_event["id"], sequence_run.orcabus_id)
+        self.assertEqual(srsc_event["status"], "DEPRECATED")
 
-    def test_create_state_only_deprecated_when_no_prior_states(self):
+    @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
+    def test_create_state_publish_failure_returns_error_and_rolls_back_state(
+        self, mock_emit_srsc_event
+    ):
+        mock_emit_srsc_event.side_effect = RuntimeError("event bus unavailable")
+        sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
+        State.objects.create(
+            sequence=sequence_run,
+            status="FAILED",
+            timestamp=now(),
+            comment="failed",
+        )
+        response = self.client.post(
+            f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
+            {"status": "RESOLVED", "comment": "Handled"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 502)
+        self.assertIn("rolled back", response.data["detail"])
+        self.assertFalse(
+            State.objects.filter(sequence=sequence_run, status="RESOLVED").exists()
+        )
+        sequence_run.refresh_from_db()
+        self.assertEqual(sequence_run.status, "SUCCEEDED")
+        mock_emit_srsc_event.assert_called_once()
+
+    @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
+    def test_create_state_only_deprecated_when_no_prior_states(
+        self, mock_emit_srsc_event
+    ):
         orphan = Sequence.objects.create(
             instrument_run_id="orphan_run_001",
             run_volume_name="vol",
@@ -558,6 +606,7 @@ class SequenceViewSetTestCase(TestCase):
             format="json",
         )
         self.assertEqual(bad.status_code, 400)
+        mock_emit_srsc_event.assert_not_called()
         good = self.client.post(
             f"{self.sequence_run_endpoint}/{orphan.orcabus_id}/state/",
             {"status": "DEPRECATED", "comment": "initial"},
@@ -565,15 +614,23 @@ class SequenceViewSetTestCase(TestCase):
         )
         self.assertEqual(good.status_code, 201)
         self.assertEqual(good.data["status"], "DEPRECATED")
+        mock_emit_srsc_event.assert_called_once()
+        srsc_event = mock_emit_srsc_event.call_args.args[0]
+        self.assertEqual(srsc_event["id"], orphan.orcabus_id)
+        self.assertEqual(srsc_event["status"], "DEPRECATED")
 
-    @patch("sequence_run_manager.viewsets.sequence_run_action.emit_srm_api_event")
-    def test_add_samplesheet_action(self, mock_emit_event):
+    @patch("sequence_run_manager.viewsets.sequence_run_action.emit_srllc_api_event")
+    @patch("sequence_run_manager.viewsets.sequence_run_action.emit_srssc_api_event")
+    def test_add_samplesheet_action(
+        self, mock_emit_srssc_event, mock_emit_srllc_event
+    ):
         """
         python manage.py test sequence_run_manager.tests.test_viewsets.SequenceViewSetTestCase.test_add_samplesheet_action
         """
         logger.info("Add samplesheet action")
         # Mock the event emission to avoid actual EventBridge calls
-        mock_emit_event.return_value = None
+        mock_emit_srssc_event.return_value = None
+        mock_emit_srllc_event.return_value = None
 
         # Read the file content from ./examples/standard-sheet-with-settings.csv
         samplesheet_path = (
@@ -612,6 +669,8 @@ class SequenceViewSetTestCase(TestCase):
             "Samplesheet added successfully",
             "Detail is expected",
         )
+        mock_emit_srssc_event.assert_called_once()
+        mock_emit_srllc_event.assert_called_once()
 
         # Get the created sequence_run (it's created by the add_samplesheet action)
         sequence_run = (

--- a/app/sequence_run_manager/tests/test_viewsets.py
+++ b/app/sequence_run_manager/tests/test_viewsets.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import base64
 import json
 
+from django.db import DatabaseError
 from django.test import TestCase
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils.timezone import now
@@ -21,6 +22,7 @@ from sequence_run_manager.models.comment import Comment, TargetType
 from sequence_run_manager.models.state import State
 
 from sequence_run_manager.urls.base import api_base
+from sequence_run_manager.viewsets.state import StateTransitionMixin
 from v2_samplesheet_parser.functions.parser import parse_samplesheet
 
 logger = logging.getLogger()
@@ -444,6 +446,28 @@ class SequenceViewSetTestCase(TestCase):
             {"RESOLVED": ["FAILED"], "DEPRECATED": ["SUCCEEDED"]},
         )
 
+    def test_state_transition_mixin_validation_rules(self):
+        mixin = StateTransitionMixin()
+
+        self.assertTrue(mixin.is_valid_next_state(None, "DEPRECATED"))
+        self.assertFalse(mixin.is_valid_next_state(None, "RESOLVED"))
+        self.assertFalse(mixin.is_valid_next_state("FAILED", "UNKNOWN"))
+        self.assertTrue(mixin._validate_state_status("FAILED", "RESOLVED"))
+
+        mixin.states_transition_validation_map = {
+            "DEPRECATED": {
+                "excluded_states": ["FAILED", "ABORTED", "RESOLVED", "DEPRECATED"]
+            },
+            "RESOLVED": {"allowed_states": ["FAILED"]},
+            "IGNORED": "unsupported-rule",
+        }
+
+        self.assertTrue(mixin.is_valid_next_state("SUCCEEDED", "DEPRECATED"))
+        self.assertFalse(mixin.is_valid_next_state("FAILED", "DEPRECATED"))
+        self.assertTrue(mixin.is_valid_next_state("FAILED", "RESOLVED"))
+        self.assertFalse(mixin.is_valid_next_state("SUCCEEDED", "RESOLVED"))
+        self.assertFalse(mixin.is_valid_next_state("FAILED", "IGNORED"))
+
     def test_patch_state_comment(self):
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
         state = (
@@ -458,6 +482,31 @@ class SequenceViewSetTestCase(TestCase):
         self.assertEqual(response.data["comment"], "Resolution note")
         state.refresh_from_db()
         self.assertEqual(state.comment, "Resolution note")
+
+    @patch("sequence_run_manager.viewsets.state.StateViewSet.get_object")
+    def test_patch_state_comment_clears_prefetch_cache(self, mock_get_object):
+        sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
+        state = (
+            State.objects.filter(sequence=sequence_run).order_by("-timestamp").first()
+        )
+        original_save = state.save
+
+        def save_with_prefetch_cache(*args, **kwargs):
+            result = original_save(*args, **kwargs)
+            state._prefetched_objects_cache = {"cached": ["value"]}
+            return result
+
+        state.save = save_with_prefetch_cache
+        mock_get_object.return_value = state
+
+        response = self.client.patch(
+            f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/{state.orcabus_id}/",
+            {"comment": "Resolution note"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(state._prefetched_objects_cache, {})
 
     def test_patch_state_requires_comment(self):
         sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
@@ -490,6 +539,35 @@ class SequenceViewSetTestCase(TestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 400)
+
+    @patch(
+        "sequence_run_manager.viewsets.state.StateViewSet.create_state_and_emit_srsc",
+        side_effect=DatabaseError("database unavailable"),
+    )
+    def test_create_state_database_failure_returns_error_and_rolls_back_state(
+        self, mock_create_state_and_emit_srsc
+    ):
+        sequence_run = Sequence.objects.get(sequence_run_id="r.AAAAAA")
+        State.objects.create(
+            sequence=sequence_run,
+            status="FAILED",
+            timestamp=now(),
+            comment="failed",
+        )
+
+        response = self.client.post(
+            f"{self.sequence_run_endpoint}/{sequence_run.orcabus_id}/state/",
+            {"status": "RESOLVED", "comment": "Handled"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("rolled back", response.data["detail"])
+        self.assertIn("correlation_id", response.data)
+        self.assertFalse(
+            State.objects.filter(sequence=sequence_run, status="RESOLVED").exists()
+        )
+        mock_create_state_and_emit_srsc.assert_called_once()
 
     @patch("sequence_run_manager.viewsets.state.emit_srsc_api_event")
     def test_create_state_resolved_after_failed(self, mock_emit_srsc_event):

--- a/app/sequence_run_manager/viewsets/sequence_run_action.py
+++ b/app/sequence_run_manager/viewsets/sequence_run_action.py
@@ -18,7 +18,10 @@ from sequence_run_manager.models import (
     Comment,
 )
 from sequence_run_manager.models.comment import TargetType
-from sequence_run_manager.aws_event_bridge.event_srv import emit_srm_api_event
+from sequence_run_manager.aws_event_bridge.event_srv import (
+    emit_srllc_api_event,
+    emit_srssc_api_event,
+)
 
 from v2_samplesheet_parser.functions.parser import parse_samplesheet
 
@@ -115,7 +118,7 @@ class SequenceRunActionViewSet(ViewSet):
         )
 
         try:
-            emit_srm_api_event(samplesheet_change_eb_payload)
+            emit_srssc_api_event(samplesheet_change_eb_payload)
             logger.info(
                 f"Samplesheet change event emitted for sequence run {sequence_run.sequence_run_id}"
             )
@@ -167,7 +170,7 @@ class SequenceRunActionViewSet(ViewSet):
                     )
                 )
                 try:
-                    emit_srm_api_event(library_linking_change_eb_payload)
+                    emit_srllc_api_event(library_linking_change_eb_payload)
                     logger.info(
                         f"Library linking change event emitted for sequence run {sequence_run.sequence_run_id}"
                     )

--- a/app/sequence_run_manager/viewsets/state.py
+++ b/app/sequence_run_manager/viewsets/state.py
@@ -6,16 +6,129 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework import mixins, status
 from rest_framework.response import Response
 from rest_framework.decorators import action
-from django.db import transaction
+from django.db import DatabaseError, transaction
 from django.utils import timezone
+from sequence_run_manager.aws_event_bridge.event_srv import emit_srsc_api_event
 from sequence_run_manager.models import State, Sequence
 from sequence_run_manager.serializers.state import (
     StateSerializer,
     StateCreateRequestSerializer,
     StateUpdateRequestSerializer,
 )
+from sequence_run_manager_proc.services.sequence_state_srv import (
+    map_sequence_run_new_state_to_srsc,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class StateTransitionMixin:
+    """
+    State transition validation and side effects for manual sequence-run states.
+
+    states_transition_validation_map structure:
+    - If value is a list: ["STATE1", "STATE2"] means only these states can
+      transition to the key.
+    - If value is a dict with "excluded_states": all states except those listed
+      can transition to the key.
+    - If value is a dict with "allowed_states": same as list format.
+
+    refer:
+        "Resolved" -- https://github.com/umccr/orcabus/issues/879
+    """
+
+    states_transition_validation_map = {
+        "RESOLVED": ["FAILED"],
+        "DEPRECATED": ["SUCCEEDED"],
+    }
+
+    def is_valid_next_state(self, current_status, request_status: str) -> bool:
+        """
+        Check if transitioning from current_status to request_status is valid.
+        """
+        if current_status is None:
+            return request_status.upper() == "DEPRECATED"
+
+        request_status_upper = request_status.upper()
+        current_status_upper = current_status.upper()
+
+        if request_status_upper not in self.states_transition_validation_map:
+            return False
+
+        validation_rule = self.states_transition_validation_map[request_status_upper]
+
+        if isinstance(validation_rule, dict):
+            if "excluded_states" in validation_rule:
+                excluded_states = [
+                    state.upper() for state in validation_rule["excluded_states"]
+                ]
+                return current_status_upper not in excluded_states
+            if "allowed_states" in validation_rule:
+                allowed_states = [
+                    state.upper() for state in validation_rule["allowed_states"]
+                ]
+                return current_status_upper in allowed_states
+
+        if isinstance(validation_rule, list):
+            allowed_states = [state.upper() for state in validation_rule]
+            return current_status_upper in allowed_states
+
+        return False
+
+    def _validate_state_status(self, current_status, request_status):
+        """Backward-compatible wrapper for the old validation method name."""
+        return self.is_valid_next_state(current_status, request_status)
+
+    def create_state_and_emit_srsc(
+        self,
+        sequence: Sequence,
+        request_status: str,
+        request_comment: str,
+    ) -> tuple[State, dict]:
+        """Create a manual sequence-run state and emit its SRSC event."""
+        logger.info(
+            "Creating manual sequence-run state: sequence_id=%s status=%s",
+            sequence.orcabus_id,
+            request_status,
+        )
+        instance = State.objects.create(
+            sequence=sequence,
+            status=request_status,
+            timestamp=timezone.now(),
+            comment=request_comment,
+        )
+        logger.info(
+            "Manual sequence-run state created: sequence_id=%s state_id=%s status=%s",
+            sequence.orcabus_id,
+            instance.orcabus_id,
+            request_status,
+        )
+
+        if request_status in self.states_transition_validation_map:
+            sequence.status = request_status
+            sequence.save(update_fields=["status"])
+
+        srsc_event = map_sequence_run_new_state_to_srsc(
+            sequence,
+            instance,
+        ).model_dump(mode="json")
+        logger.info(
+            "Manual SRSC event built: sequence_id=%s state_id=%s event_id=%s status=%s",
+            sequence.orcabus_id,
+            instance.orcabus_id,
+            srsc_event.get("id"),
+            request_status,
+        )
+
+        emit_srsc_api_event(srsc_event)
+        logger.info(
+            "Manual SRSC event emitted: sequence_id=%s state_id=%s event_id=%s status=%s",
+            sequence.orcabus_id,
+            instance.orcabus_id,
+            srsc_event.get("id"),
+            request_status,
+        )
+        return instance, srsc_event
 
 
 @extend_schema_view(
@@ -33,6 +146,7 @@ logger = logging.getLogger(__name__)
     ),
 )
 class StateViewSet(
+    StateTransitionMixin,
     mixins.CreateModelMixin,
     mixins.UpdateModelMixin,
     mixins.ListModelMixin,
@@ -43,16 +157,6 @@ class StateViewSet(
     http_method_names = ["get", "post", "patch"]
     pagination_class = None
     lookup_value_regex = "[^/]+"  # to allow id prefix
-
-    """
-    states_transition_validation_map for state creation, update
-    refer:
-        "Resolved" -- https://github.com/umccr/orcabus/issues/879
-    """
-    states_transition_validation_map = {
-        "RESOLVED": ["FAILED"],
-        "DEPRECATED": ["SUCCEEDED"],
-    }
 
     def get_queryset(self):
         return State.objects.filter(sequence=self.kwargs["orcabus_id"])
@@ -99,7 +203,7 @@ class StateViewSet(
         latest_state = sequence.get_latest_state()
         # Handle case when there's no latest state - only allow DEPRECATED
         if not latest_state:
-            if request_status != "DEPRECATED":
+            if not self.is_valid_next_state(None, request_status):
                 return Response(
                     {
                         "detail": "No state found for workflow run '{}'. Only DEPRECATED is allowed when there are no states.".format(
@@ -112,7 +216,7 @@ class StateViewSet(
         else:
             latest_status = latest_state.status
             # check if the state status is valid
-            if not self._validate_state_status(latest_status, request_status):
+            if not self.is_valid_next_state(latest_status, request_status):
                 return Response(
                     {
                         "detail": "Invalid state request. Can't add state '{}' to '{}'".format(
@@ -124,23 +228,36 @@ class StateViewSet(
         # create state and sync sequence status atomically
         try:
             with transaction.atomic():
-                instance = State.objects.create(
-                    sequence=sequence,
-                    status=request_status,
-                    timestamp=timezone.now(),
-                    comment=request_comment,
+                instance, _ = self.create_state_and_emit_srsc(
+                    sequence,
+                    request_status,
+                    request_comment,
                 )
-                # update sequence status if the new state is in states_transition_validation_map
-                if request_status in self.states_transition_validation_map:
-                    sequence.status = request_status
-                    sequence.save(update_fields=["status"])
-        except Exception:
+        except DatabaseError:
             logger.exception(
-                "Failed to create state for sequence %s", sequence_orcabus_id
+                "Manual state transition failed during database operation and was rolled back: sequence_id=%s requested_status=%s",
+                sequence_orcabus_id,
+                request_status,
             )
             return Response(
-                {"detail": "Failed to create state. Please try again later."},
+                {
+                    "detail": "Failed to create sequence-run state. The operation was rolled back.",
+                    "correlation_id": f"{sequence_orcabus_id}:{request_status}",
+                },
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        except Exception:
+            logger.exception(
+                "Manual state transition failed while emitting SRSC event and was rolled back: sequence_id=%s requested_status=%s",
+                sequence_orcabus_id,
+                request_status,
+            )
+            return Response(
+                {
+                    "detail": "Failed to create sequence-run state and emit SRSC event. The operation was rolled back.",
+                    "correlation_id": f"{sequence_orcabus_id}:{request_status}",
+                },
+                status=status.HTTP_502_BAD_GATEWAY,
             )
 
         data = StateSerializer(instance).data
@@ -178,19 +295,3 @@ class StateViewSet(
         data = StateSerializer(instance).data
         headers = self.get_success_headers(data)
         return Response(data, status=status.HTTP_200_OK, headers=headers)
-
-    def _validate_state_status(self, current_status, request_status):
-        """
-        check if the state status is valid:
-        states_transition_validation_map[request_state] in current_state.status
-        """
-        request_status_upper = request_status.upper()
-        current_status_upper = current_status.upper()
-        if request_status_upper not in self.states_transition_validation_map:
-            return False
-        if (
-            current_status_upper
-            not in self.states_transition_validation_map[request_status_upper]
-        ):
-            return False
-        return True

--- a/app/sequence_run_manager/viewsets/state.py
+++ b/app/sequence_run_manager/viewsets/state.py
@@ -98,7 +98,7 @@ class StateTransitionMixin:
             comment=request_comment,
         )
         logger.info(
-            "Manual sequence-run state created: sequence_id=%s state_id=%s status=%s",
+            "Manual sequence-run state persisted (pending SRSC emission): sequence_id=%s state_id=%s status=%s",
             sequence.orcabus_id,
             instance.orcabus_id,
             request_status,

--- a/app/sequence_run_manager/viewsets/state.py
+++ b/app/sequence_run_manager/viewsets/state.py
@@ -1,4 +1,5 @@
 import logging
+from functools import partial
 
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from drf_spectacular.types import OpenApiTypes
@@ -20,6 +21,10 @@ from sequence_run_manager_proc.services.sequence_state_srv import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class InvalidStateTransition(ValueError):
+    """Raised when locked transition validation rejects a requested state."""
 
 
 class StateTransitionMixin:
@@ -79,13 +84,13 @@ class StateTransitionMixin:
         """Backward-compatible wrapper for the old validation method name."""
         return self.is_valid_next_state(current_status, request_status)
 
-    def create_state_and_emit_srsc(
+    def create_state_and_build_srsc(
         self,
         sequence: Sequence,
         request_status: str,
         request_comment: str,
     ) -> tuple[State, dict]:
-        """Create a manual sequence-run state and emit its SRSC event."""
+        """Create a manual sequence-run state and build its SRSC event."""
         logger.info(
             "Creating manual sequence-run state: sequence_id=%s status=%s",
             sequence.orcabus_id,
@@ -120,15 +125,42 @@ class StateTransitionMixin:
             request_status,
         )
 
-        emit_srsc_api_event(srsc_event)
+        return instance, srsc_event
+
+    def publish_srsc_after_commit(
+        self,
+        *,
+        srsc_event: dict,
+        sequence_id: str,
+        state_id: str,
+        request_status: str,
+    ) -> None:
+        """Publish a committed transition, logging enough context for recovery."""
+        try:
+            emit_srsc_api_event(srsc_event)
+        except Exception:
+            # Publication is best-effort until a transactional outbox is added.
+            # Keep this message queryable so CloudWatch can alarm on it and the
+            # event can be reconstructed from sequence_id/state_id.
+            logger.exception(
+                "Manual SRSC publication failed after database commit: "
+                "sequence_id=%s state_id=%s event_id=%s status=%s "
+                "recoverable=true",
+                sequence_id,
+                state_id,
+                srsc_event.get("id"),
+                request_status,
+            )
+            return
+
         logger.info(
-            "Manual SRSC event emitted: sequence_id=%s state_id=%s event_id=%s status=%s",
-            sequence.orcabus_id,
-            instance.orcabus_id,
+            "Manual SRSC event emitted after database commit: "
+            "sequence_id=%s state_id=%s event_id=%s status=%s",
+            sequence_id,
+            state_id,
             srsc_event.get("id"),
             request_status,
         )
-        return instance, srsc_event
 
 
 @extend_schema_view(
@@ -193,6 +225,7 @@ class StateViewSet(
 
         sequence_orcabus_id = self.kwargs.get("orcabus_id")
         sequence = Sequence.objects.get(orcabus_id=sequence_orcabus_id)
+        observed_status = sequence.status
 
         body = StateCreateRequestSerializer(data=request.data)
         body.is_valid(raise_exception=True)
@@ -200,37 +233,67 @@ class StateViewSet(
         request_status = vd["status"].upper()
         request_comment = vd["comment"]
 
-        current_state = sequence.status
-        # Handle case when there's no current state - only allow DEPRECATED
-        if not current_state:
-            if not self.is_valid_next_state(None, request_status):
-                return Response(
-                    {
-                        "detail": "No current state found for workflow run '{}'. Only DEPRECATED is allowed when there is no current state.".format(
-                            sequence_orcabus_id
-                        )
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-        else:
-            # check if the state status is valid
-            if not self.is_valid_next_state(current_state, request_status):
-                return Response(
-                    {
-                        "detail": "Invalid state request. Can't add state '{}' to '{}'".format(
-                            request_status, current_state
-                        )
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-        # create state and sync sequence status atomically
         try:
             with transaction.atomic():
-                instance, _ = self.create_state_and_emit_srsc(
+                # The Sequence row is the shared lock target for every state
+                # transition, including sequences that do not have State rows.
+                sequence = Sequence.objects.select_for_update().get(
+                    orcabus_id=sequence_orcabus_id
+                )
+                current_status = sequence.status
+
+                if current_status != observed_status:
+                    logger.warning(
+                        "Sequence status changed before transition lock was acquired: "
+                        "sequence_id=%s requested_status=%s observed_status=%s "
+                        "locked_status=%s concurrent_update=true",
+                        sequence_orcabus_id,
+                        request_status,
+                        observed_status,
+                        current_status,
+                    )
+
+                if not self.is_valid_next_state(current_status, request_status):
+                    logger.warning(
+                        "Manual state transition rejected after locked validation: "
+                        "sequence_id=%s requested_status=%s current_status=%s",
+                        sequence_orcabus_id,
+                        request_status,
+                        current_status,
+                    )
+                    if current_status is None:
+                        raise InvalidStateTransition(
+                            "No current state found for workflow run '{}'. Only "
+                            "DEPRECATED is allowed when there is no current state.".format(
+                                sequence_orcabus_id
+                            )
+                        )
+                    raise InvalidStateTransition(
+                        "Invalid state request. Can't add state '{}' to '{}'".format(
+                            request_status, current_status
+                        )
+                    )
+
+                instance, srsc_event = self.create_state_and_build_srsc(
                     sequence,
                     request_status,
                     request_comment,
                 )
+                transaction.on_commit(
+                    partial(
+                        self.publish_srsc_after_commit,
+                        srsc_event=srsc_event,
+                        sequence_id=str(sequence.orcabus_id),
+                        state_id=str(instance.orcabus_id),
+                        request_status=request_status,
+                    ),
+                    robust=True,
+                )
+        except InvalidStateTransition as exc:
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except DatabaseError:
             logger.exception(
                 "Manual state transition failed during database operation and was rolled back: sequence_id=%s requested_status=%s",
@@ -246,16 +309,16 @@ class StateViewSet(
             )
         except Exception:
             logger.exception(
-                "Manual state transition failed while constructing or emitting the SRSC event and was rolled back: sequence_id=%s requested_status=%s",
+                "Manual state transition failed before commit and was rolled back: sequence_id=%s requested_status=%s",
                 sequence_orcabus_id,
                 request_status,
             )
             return Response(
                 {
-                    "detail": "Failed to create sequence-run state and publish its SRSC event. The operation was rolled back.",
+                    "detail": "Failed to create sequence-run state. The operation was rolled back.",
                     "correlation_id": f"{sequence_orcabus_id}:{request_status}",
                 },
-                status=status.HTTP_502_BAD_GATEWAY,
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
         data = StateSerializer(instance).data

--- a/app/sequence_run_manager/viewsets/state.py
+++ b/app/sequence_run_manager/viewsets/state.py
@@ -200,27 +200,25 @@ class StateViewSet(
         request_status = vd["status"].upper()
         request_comment = vd["comment"]
 
-        latest_state = sequence.get_latest_state()
-        # Handle case when there's no latest state - only allow DEPRECATED
-        if not latest_state:
+        current_state = sequence.status
+        # Handle case when there's no current state - only allow DEPRECATED
+        if not current_state:
             if not self.is_valid_next_state(None, request_status):
                 return Response(
                     {
-                        "detail": "No state found for workflow run '{}'. Only DEPRECATED is allowed when there are no states.".format(
+                        "detail": "No current state found for workflow run '{}'. Only DEPRECATED is allowed when there is no current state.".format(
                             sequence_orcabus_id
                         )
                     },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
-            latest_status = None
         else:
-            latest_status = latest_state.status
             # check if the state status is valid
-            if not self.is_valid_next_state(latest_status, request_status):
+            if not self.is_valid_next_state(current_state, request_status):
                 return Response(
                     {
                         "detail": "Invalid state request. Can't add state '{}' to '{}'".format(
-                            request_status, latest_status
+                            request_status, current_state
                         )
                     },
                     status=status.HTTP_400_BAD_REQUEST,

--- a/app/sequence_run_manager/viewsets/state.py
+++ b/app/sequence_run_manager/viewsets/state.py
@@ -248,13 +248,13 @@ class StateViewSet(
             )
         except Exception:
             logger.exception(
-                "Manual state transition failed while emitting SRSC event and was rolled back: sequence_id=%s requested_status=%s",
+                "Manual state transition failed while constructing or emitting the SRSC event and was rolled back: sequence_id=%s requested_status=%s",
                 sequence_orcabus_id,
                 request_status,
             )
             return Response(
                 {
-                    "detail": "Failed to create sequence-run state and emit SRSC event. The operation was rolled back.",
+                    "detail": "Failed to create sequence-run state and publish its SRSC event. The operation was rolled back.",
                     "correlation_id": f"{sequence_orcabus_id}:{request_status}",
                 },
                 status=status.HTTP_502_BAD_GATEWAY,

--- a/app/sequence_run_manager_proc/services/sequence_state_srv.py
+++ b/app/sequence_run_manager_proc/services/sequence_state_srv.py
@@ -47,8 +47,8 @@ def map_sequence_run_new_state_to_srsc(
         runVolumeName=sequence.run_volume_name or "",
         runFolderPath=sequence.run_folder_path or "",
         runDataUri=sequence.run_data_uri or "",
-        sampleSheetName=sequence.sample_sheet_name or "",
+        sampleSheetName=sequence.sample_sheet_name,
         startTime=sequence.start_time,
-        endTime=sequence.end_time or "",
+        endTime=sequence.end_time,
         status=new_state.status or "",
     )

--- a/app/sequence_run_manager_proc/services/sequence_state_srv.py
+++ b/app/sequence_run_manager_proc/services/sequence_state_srv.py
@@ -1,10 +1,10 @@
 import logging
 
 from django.db import transaction
-from django.db.models import QuerySet
 
-from sequence_run_manager.models.sequence import Sequence, SequenceStatus
+from sequence_run_manager.models.sequence import Sequence
 from sequence_run_manager.models.state import State
+from sequence_run_manager_proc.domain.events.srsc import SequenceRunStateChange
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -29,4 +29,26 @@ def create_sequence_state_from_bssh_event(payload: dict) -> None:
     )
     logger.info(
         f"Created new Sequence State (sequence_run_id={sequence.sequence_run_id}, status={status})"
+    )
+
+
+def map_sequence_run_new_state_to_srsc(
+    sequence: Sequence, new_state: State
+) -> SequenceRunStateChange:
+    """
+    Map a persisted sequence run state to a SequenceRunStateChange event.
+
+    Sequence metadata comes from the Sequence row, while status comes from the
+    newly created State row that triggered the API event.
+    """
+    return SequenceRunStateChange(
+        id=sequence.orcabus_id,
+        instrumentRunId=sequence.instrument_run_id,
+        runVolumeName=sequence.run_volume_name,
+        runFolderPath=sequence.run_folder_path,
+        runDataUri=sequence.run_data_uri,
+        sampleSheetName=sequence.sample_sheet_name,
+        startTime=sequence.start_time,
+        endTime=sequence.end_time,
+        status=new_state.status,
     )

--- a/app/sequence_run_manager_proc/services/sequence_state_srv.py
+++ b/app/sequence_run_manager_proc/services/sequence_state_srv.py
@@ -44,11 +44,11 @@ def map_sequence_run_new_state_to_srsc(
     return SequenceRunStateChange(
         id=sequence.orcabus_id,
         instrumentRunId=sequence.instrument_run_id,
-        runVolumeName=sequence.run_volume_name,
-        runFolderPath=sequence.run_folder_path,
-        runDataUri=sequence.run_data_uri,
-        sampleSheetName=sequence.sample_sheet_name,
+        runVolumeName=sequence.run_volume_name or "",
+        runFolderPath=sequence.run_folder_path or "",
+        runDataUri=sequence.run_data_uri or "",
+        sampleSheetName=sequence.sample_sheet_name or "",
         startTime=sequence.start_time,
-        endTime=sequence.end_time,
-        status=new_state.status,
+        endTime=sequence.end_time or "",
+        status=new_state.status or "",
     )

--- a/app/sequence_run_manager_proc/tests/test_sequence_state_srv.py
+++ b/app/sequence_run_manager_proc/tests/test_sequence_state_srv.py
@@ -9,7 +9,7 @@ from sequence_run_manager_proc.tests.case import SequenceRunProcUnitTestCase
 
 
 class SequenceStateSrvUnitTests(SequenceRunProcUnitTestCase):
-    def test_map_sequence_run_new_state_uses_empty_strings_for_null_fields(self):
+    def test_map_sequence_run_new_state_uses_schema_compatible_null_values(self):
         sequence = SequenceFactory(
             run_volume_name=None,
             run_folder_path=None,
@@ -27,12 +27,8 @@ class SequenceStateSrvUnitTests(SequenceRunProcUnitTestCase):
             mode="json"
         )
 
-        for field in (
-            "runVolumeName",
-            "runFolderPath",
-            "runDataUri",
-            "sampleSheetName",
-            "endTime",
-            "status",
-        ):
+        for field in ("runVolumeName", "runFolderPath", "runDataUri", "status"):
             self.assertEqual(event[field], "")
+
+        self.assertIsNone(event["sampleSheetName"])
+        self.assertIsNone(event["endTime"])

--- a/app/sequence_run_manager_proc/tests/test_sequence_state_srv.py
+++ b/app/sequence_run_manager_proc/tests/test_sequence_state_srv.py
@@ -1,0 +1,38 @@
+from django.utils import timezone
+
+from sequence_run_manager.models.state import State
+from sequence_run_manager.tests.factories import SequenceFactory
+from sequence_run_manager_proc.services.sequence_state_srv import (
+    map_sequence_run_new_state_to_srsc,
+)
+from sequence_run_manager_proc.tests.case import SequenceRunProcUnitTestCase
+
+
+class SequenceStateSrvUnitTests(SequenceRunProcUnitTestCase):
+    def test_map_sequence_run_new_state_uses_empty_strings_for_null_fields(self):
+        sequence = SequenceFactory(
+            run_volume_name=None,
+            run_folder_path=None,
+            run_data_uri=None,
+            sample_sheet_name=None,
+            end_time=None,
+        )
+        new_state = State(
+            sequence=sequence,
+            status=None,
+            timestamp=timezone.now(),
+        )
+
+        event = map_sequence_run_new_state_to_srsc(sequence, new_state).model_dump(
+            mode="json"
+        )
+
+        for field in (
+            "runVolumeName",
+            "runFolderPath",
+            "runDataUri",
+            "sampleSheetName",
+            "endTime",
+            "status",
+        ):
+            self.assertEqual(event[field], "")

--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { StatelessStack } from '../infrastructure/toolchain/stateless-stack';
 import { TOOLCHAIN_ENVIRONMENT } from '@orcabus/platform-cdk-constructs/deployment-stack-pipeline';

--- a/package.json
+++ b/package.json
@@ -22,23 +22,23 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.3.0",
-    "aws-cdk": "^2.1107.0",
-    "cdk-nag": "^2.37.55",
-    "eslint": "^10.0.2",
-    "globals": "^17.3.0",
-    "jest": "^30.2.0",
-    "prettier": "^3.8.1",
+    "@types/node": "^25.9.3",
+    "aws-cdk": "^2.1135.0",
+    "cdk-nag": "^2.38.2",
+    "eslint": "^10.8.1",
+    "globals": "^17.9.0",
+    "jest": "^30.4.2",
+    "prettier": "^3.9.6",
     "test-js": "^0.0.4",
-    "ts-jest": "^29.4.6",
+    "ts-jest": "^29.4.12",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "^8.56.1"
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.66.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.260.0-alpha.0",
-    "@orcabus/platform-cdk-constructs": "1.7.1",
-    "aws-cdk-lib": "^2.260.0",
-    "constructs": "^10.6.0"
+    "@aws-cdk/aws-lambda-python-alpha": "2.263.0-alpha.0",
+    "@orcabus/platform-cdk-constructs": "1.8.0",
+    "aws-cdk-lib": "^2.263.0",
+    "constructs": "^10.8.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,72 +5,69 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
-  flatted@<=3.4.1: '>=3.4.2'
-  handlebars@<4.7.9: '>=4.7.9'
-  js-yaml@<=4.1.1: '>=4.2.0'
-  minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
-  picomatch@<4.0.4: '>=4.0.4'
+  brace-expansion@<1.1.18: ^1.1.18
+  brace-expansion@>=2.0.0 <2.1.4: ^2.1.4
+  brace-expansion@>=3.0.0 <5.0.9: ^5.0.9
 
 importers:
 
   .:
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha':
-        specifier: 2.260.0-alpha.0
-        version: 2.260.0-alpha.0(aws-cdk-lib@2.260.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 2.263.0-alpha.0
+        version: 2.263.0-alpha.0(aws-cdk-lib@2.264.0(constructs@10.8.1))(constructs@10.8.1)
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.7.1
-        version: 1.7.1(@aws-cdk/aws-lambda-python-alpha@2.260.0-alpha.0(aws-cdk-lib@2.260.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.260.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 1.8.0
+        version: 1.8.0(@aws-cdk/aws-lambda-python-alpha@2.263.0-alpha.0(aws-cdk-lib@2.264.0(constructs@10.8.1))(constructs@10.8.1))(aws-cdk-lib@2.264.0(constructs@10.8.1))(constructs@10.8.1)
       aws-cdk-lib:
-        specifier: ^2.260.0
-        version: 2.260.0(constructs@10.6.0)
+        specifier: ^2.263.0
+        version: 2.264.0(constructs@10.8.1)
       constructs:
-        specifier: ^10.6.0
-        version: 10.6.0
+        specifier: ^10.8.1
+        version: 10.8.1
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.5.0)
+        version: 10.0.1(eslint@10.8.1)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: ^25.3.0
+        specifier: ^25.9.3
         version: 25.9.4
       aws-cdk:
-        specifier: ^2.1107.0
-        version: 2.1128.0
+        specifier: ^2.1135.0
+        version: 2.1135.1
       cdk-nag:
-        specifier: ^2.37.55
-        version: 2.38.2(aws-cdk-lib@2.260.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: ^2.38.2
+        version: 2.38.2(aws-cdk-lib@2.264.0(constructs@10.8.1))(constructs@10.8.1)
       eslint:
-        specifier: ^10.0.2
-        version: 10.5.0
+        specifier: ^10.8.1
+        version: 10.8.1
       globals:
-        specifier: ^17.3.0
-        version: 17.6.0
+        specifier: ^17.9.0
+        version: 17.9.0
       jest:
-        specifier: ^30.2.0
-        version: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3))
       prettier:
-        specifier: ^3.8.1
-        version: 3.8.4
+        specifier: ^3.9.6
+        version: 3.9.6
       test-js:
         specifier: ^0.0.4
         version: 0.0.4
       ts-jest:
-        specifier: ^29.4.6
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3)))(typescript@5.9.3)
+        specifier: ^29.4.12
+        version: 29.4.12(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3)))(typescript@6.0.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.9.4)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.9.4)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       typescript-eslint:
-        specifier: ^8.56.1
-        version: 8.61.1(eslint@10.5.0)(typescript@5.9.3)
+        specifier: ^8.66.0
+        version: 8.67.0(eslint@10.8.1)(typescript@6.0.3)
 
 packages:
 
@@ -80,15 +77,15 @@ packages:
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
     resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==}
 
-  '@aws-cdk/aws-lambda-python-alpha@2.260.0-alpha.0':
-    resolution: {integrity: sha512-u+HvrSzbCwKmiXC6H9kJNLfYS6ugS8907ktgFgUE0l4+dkTeCnFlr7Jt/7WcAwDNbZnOkbwSo8eh5YHmK/Sfrw==}
+  '@aws-cdk/aws-lambda-python-alpha@2.263.0-alpha.0':
+    resolution: {integrity: sha512-1OgLG7TGGH5/Wt7firHTOFyxU6ymZNaANELq62h1yNfTBOSNsNhdzkWLYxhoXDPBvNndEsmUnKVCij7U+dXsqQ==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
-      aws-cdk-lib: ^2.260.0
+      aws-cdk-lib: ^2.263.0
       constructs: ^10.5.0
 
-  '@aws-cdk/cloud-assembly-schema@54.4.0':
-    resolution: {integrity: sha512-v04S/TkvlL+/SWw5BoBYy0XaCQCNdcgELmN2ACJqEbGxzCEzzFcTQNE8WH/6j0c+uKkOXXsdoCG0/3Z73BqzDQ==}
+  '@aws-cdk/cloud-assembly-schema@54.17.0':
+    resolution: {integrity: sha512-wV1GmMM5AvDkiJIenb9aJcBiGTa5KwX/C/mIjFZCsWsB5b1rEMLnwMageqrOpL2mWKicpxqS8ofF/Yte4Lm3Dg==}
     engines: {node: '>= 18.0.0'}
     bundledDependencies:
       - jsonschema
@@ -286,8 +283,8 @@ packages:
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.2.1':
@@ -450,8 +447,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@orcabus/platform-cdk-constructs@1.7.1':
-    resolution: {integrity: sha512-9/jesp4Y2RVJJ/kcjk3afJlooVNmnNxSGLfRCQcFJDhjp4UGY3/wbNaHxpEpPRV9bw145V12Pt0+0zvHe5NouQ==}
+  '@orcabus/platform-cdk-constructs@1.8.0':
+    resolution: {integrity: sha512-hSwpr/KJKJGKzJ3j0IJ96pHuwLJ6+u6DmCiVvvvUWCTvPmOiIZv15yGRJZP1qK4tXvescVw9ke0iqoAUKrkn5A==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -534,63 +531,63 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@typescript-eslint/eslint-plugin@8.61.1':
-    resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
+  '@typescript-eslint/eslint-plugin@8.67.0':
+    resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.61.1
+      '@typescript-eslint/parser': ^8.67.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.61.1':
-    resolution: {integrity: sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.61.1':
-    resolution: {integrity: sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.61.1':
-    resolution: {integrity: sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.61.1':
-    resolution: {integrity: sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.61.1':
-    resolution: {integrity: sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==}
+  '@typescript-eslint/parser@8.67.0':
+    resolution: {integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.61.1':
-    resolution: {integrity: sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.61.1':
-    resolution: {integrity: sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==}
+  '@typescript-eslint/project-service@8.67.0':
+    resolution: {integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.61.1':
-    resolution: {integrity: sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==}
+  '@typescript-eslint/scope-manager@8.67.0':
+    resolution: {integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.67.0':
+    resolution: {integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.67.0':
+    resolution: {integrity: sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.61.1':
-    resolution: {integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==}
+  '@typescript-eslint/types@8.67.0':
+    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.67.0':
+    resolution: {integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.67.0':
+    resolution: {integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.67.0':
+    resolution: {integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.1':
@@ -764,15 +761,16 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
-  argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
-  aws-cdk-lib@2.260.0:
-    resolution: {integrity: sha512-2PPG+hbPDot8+ibkb5Jl9y3OY5rBE6TFwjzOi+yEyU4ZG6u8bM4DDKhhBi/S20NqqSFDso9rH1txVJAdwXNiuQ==}
+  aws-cdk-lib@2.264.0:
+    resolution: {integrity: sha512-TzeWc4aM2qftdoWzIgqV7DotzUO9+DqYLXHvL2qygZqkrJdvITTp8ojHstxYPH40FfA+RL4x5hVfa52NCTB0ZA==}
     engines: {node: '>= 20.0.0'}
     peerDependencies:
       constructs: ^10.5.0
     bundledDependencies:
+      - '@aws/cloudformation-validate'
       - '@balena/dockerignore'
       - '@aws-cdk/cloud-assembly-api'
       - case
@@ -782,12 +780,11 @@ packages:
       - minimatch
       - punycode
       - semver
-      - table
       - yaml
       - mime-types
 
-  aws-cdk@2.1128.0:
-    resolution: {integrity: sha512-CXPl6Yu0gDqrS2GYDPoMCQbdJFS0tupzN8nuaTku3fewTdQJhHGK/2QpwMV/mVgsTTHB9riXT3Zt/k4trh8tCw==}
+  aws-cdk@2.1135.1:
+    resolution: {integrity: sha512-g1jcMfWlyYtGamFJ/kPBOCuchl3NfwTF2UwOLTIDN0nJbGm84EAO+c8DlYnaemM8UmKFkdoq4BGdmiNL5nHWwA==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
 
@@ -828,15 +825,15 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -911,8 +908,8 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  constructs@10.6.0:
-    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==}
+  constructs@10.8.1:
+    resolution: {integrity: sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -999,8 +996,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.5.0:
-    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
+  eslint@10.8.1:
+    resolution: {integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1012,6 +1009,11 @@ packages:
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -1057,7 +1059,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=4.0.4'
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1122,8 +1124,8 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  globals@17.6.0:
-    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
+  globals@17.9.0:
+    resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
     engines: {node: '>=18'}
 
   graceful-fs@4.2.11:
@@ -1349,8 +1351,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.0.0:
-    resolution: {integrity: sha512-GSvaPUbk1U+FMZ7rJzF+F8e5YVtu7KnD40et/5rBXXRBv2jCO9L3qCewvIDDdudC0QycTFlf6EAA+h3kxBsuUw==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1527,6 +1529,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -1543,8 +1549,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -1611,6 +1617,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -1680,8 +1689,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-jest@29.4.11:
-    resolution: {integrity: sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==}
+  ts-jest@29.4.12:
+    resolution: {integrity: sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -1740,15 +1749,15 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  typescript-eslint@8.61.1:
-    resolution: {integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==}
+  typescript-eslint@8.67.0:
+    resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1838,12 +1847,12 @@ snapshots:
 
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
 
-  '@aws-cdk/aws-lambda-python-alpha@2.260.0-alpha.0(aws-cdk-lib@2.260.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@aws-cdk/aws-lambda-python-alpha@2.263.0-alpha.0(aws-cdk-lib@2.264.0(constructs@10.8.1))(constructs@10.8.1)':
     dependencies:
-      aws-cdk-lib: 2.260.0(constructs@10.6.0)
-      constructs: 10.6.0
+      aws-cdk-lib: 2.264.0(constructs@10.8.1)
+      constructs: 10.8.1
 
-  '@aws-cdk/cloud-assembly-schema@54.4.0': {}
+  '@aws-cdk/cloud-assembly-schema@54.17.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -2054,9 +2063,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.1)':
     dependencies:
-      eslint: 10.5.0
+      eslint: 10.8.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -2069,7 +2078,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.7.0':
     dependencies:
       '@eslint/core': 1.2.1
 
@@ -2077,9 +2086,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.5.0)':
+  '@eslint/js@10.0.1(eslint@10.8.1)':
     optionalDependencies:
-      eslint: 10.5.0
+      eslint: 10.8.1
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -2118,7 +2127,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 5.0.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -2132,7 +2141,7 @@ snapshots:
       jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.4.2(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))':
+  '@jest/core@30.4.2(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.4.1
       '@jest/pattern': 30.4.0
@@ -2148,7 +2157,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
+      jest-config: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3))
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -2332,11 +2341,11 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.7.1(@aws-cdk/aws-lambda-python-alpha@2.260.0-alpha.0(aws-cdk-lib@2.260.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.260.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@orcabus/platform-cdk-constructs@1.8.0(@aws-cdk/aws-lambda-python-alpha@2.263.0-alpha.0(aws-cdk-lib@2.264.0(constructs@10.8.1))(constructs@10.8.1))(aws-cdk-lib@2.264.0(constructs@10.8.1))(constructs@10.8.1)':
     dependencies:
-      '@aws-cdk/aws-lambda-python-alpha': 2.260.0-alpha.0(aws-cdk-lib@2.260.0(constructs@10.6.0))(constructs@10.6.0)
-      aws-cdk-lib: 2.260.0(constructs@10.6.0)
-      constructs: 10.6.0
+      '@aws-cdk/aws-lambda-python-alpha': 2.263.0-alpha.0(aws-cdk-lib@2.264.0(constructs@10.8.1))(constructs@10.8.1)
+      aws-cdk-lib: 2.264.0(constructs@10.8.1)
+      constructs: 10.8.1
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -2420,95 +2429,95 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3))(eslint@10.8.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/type-utils': 8.61.1(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.61.1
-      eslint: 10.5.0
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
+      eslint: 10.8.1
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.61.1
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3
-      eslint: 10.5.0
-      typescript: 5.9.3
+      eslint: 10.8.1
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.61.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.67.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.67.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.61.1':
+  '@typescript-eslint/scope-manager@8.67.0':
     dependencies:
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/visitor-keys': 8.61.1
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
 
-  '@typescript-eslint/tsconfig-utils@8.61.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.61.1(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0)(typescript@5.9.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.5.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      eslint: 10.8.1
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.61.1': {}
+  '@typescript-eslint/types@8.67.0': {}
 
-  '@typescript-eslint/typescript-estree@8.61.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.67.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/visitor-keys': 8.61.1
+      '@typescript-eslint/project-service': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.67.0(eslint@10.8.1)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.9.3)
-      eslint: 10.5.0
-      typescript: 5.9.3
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      eslint: 10.8.1
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.61.1':
+  '@typescript-eslint/visitor-keys@8.67.0':
     dependencies:
-      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/types': 8.67.0
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.1': {}
@@ -2619,20 +2628,22 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   arg@4.1.3: {}
 
-  argparse@2.0.1: {}
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
-  aws-cdk-lib@2.260.0(constructs@10.6.0):
+  aws-cdk-lib@2.264.0(constructs@10.8.1):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.282
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
-      '@aws-cdk/cloud-assembly-schema': 54.4.0
-      constructs: 10.6.0
+      '@aws-cdk/cloud-assembly-schema': 54.17.0
+      constructs: 10.8.1
 
-  aws-cdk@2.1128.0: {}
+  aws-cdk@2.1135.1: {}
 
   babel-jest@30.4.1(@babel/core@7.29.7):
     dependencies:
@@ -2692,16 +2703,16 @@ snapshots:
 
   baseline-browser-mapping@2.10.38: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2731,10 +2742,10 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
-  cdk-nag@2.38.2(aws-cdk-lib@2.260.0(constructs@10.6.0))(constructs@10.6.0):
+  cdk-nag@2.38.2(aws-cdk-lib@2.264.0(constructs@10.8.1))(constructs@10.8.1):
     dependencies:
-      aws-cdk-lib: 2.260.0(constructs@10.6.0)
-      constructs: 10.6.0
+      aws-cdk-lib: 2.264.0(constructs@10.8.1)
+      constructs: 10.8.1
 
   chalk@4.1.2:
     dependencies:
@@ -2765,7 +2776,7 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  constructs@10.6.0: {}
+  constructs@10.8.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -2822,12 +2833,12 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.5.0:
+  eslint@10.8.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.1)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
+      '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@humanfs/node': 0.16.8
@@ -2862,6 +2873,8 @@ snapshots:
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
+
+  esprima@4.0.1: {}
 
   esquery@1.7.0:
     dependencies:
@@ -2973,7 +2986,7 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  globals@17.6.0: {}
+  globals@17.9.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -3095,15 +3108,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3)):
+  jest-cli@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
+      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3))
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
+      jest-config: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3))
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.3
@@ -3114,7 +3127,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3)):
+  jest-config@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/get-type': 30.1.0
@@ -3141,7 +3154,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.9.4
-      ts-node: 10.9.2(@types/node@25.9.4)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@25.9.4)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -3362,12 +3375,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3)):
+  jest@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
+      '@jest/core': 30.4.2(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3))
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
+      jest-cli: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -3377,9 +3390,10 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.0.0:
+  js-yaml@3.15.1:
     dependencies:
-      argparse: 2.0.1
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   jsesc@3.1.0: {}
 
@@ -3438,15 +3452,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -3527,6 +3541,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
@@ -3537,7 +3553,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.4: {}
+  prettier@3.9.6: {}
 
   pretty-format@30.4.1:
     dependencies:
@@ -3584,6 +3600,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
     dependencies:
@@ -3647,22 +3665,22 @@ snapshots:
 
   tmpl@1.0.5: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.12(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3))
+      jest: 30.4.2(@types/node@25.9.4)(ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.8.5
       type-fest: 4.41.0
-      typescript: 5.9.3
+      typescript: 6.0.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.7
@@ -3671,7 +3689,7 @@ snapshots:
       babel-jest: 30.4.1(@babel/core@7.29.7)
       jest-util: 30.4.1
 
-  ts-node@10.9.2(@types/node@25.9.4)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@25.9.4)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -3685,7 +3703,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -3702,18 +3720,18 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  typescript-eslint@8.61.1(eslint@10.5.0)(typescript@5.9.3):
+  typescript-eslint@8.67.0(eslint@10.8.1)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@5.9.3))(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0)(typescript@5.9.3)
-      eslint: 10.5.0
-      typescript: 5.9.3
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3))(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@6.0.3)
+      eslint: 10.8.1
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,13 +1,16 @@
 allowBuilds:
   unrs-resolver: false
-
-onlyBuiltDependencies:
-  - unrs-resolver
-
+minimumReleaseAgeExclude:
+  - brace-expansion@2.1.2
+  - brace-expansion@1.1.16
+  - brace-expansion@5.0.7
+  - brace-expansion@1.1.17
+  - brace-expansion@2.1.3
+  - brace-expansion@5.0.8
+  - brace-expansion@5.0.9
+  - brace-expansion@2.1.4
+  - brace-expansion@1.1.18
 overrides:
-  brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
-  flatted@<=3.4.1: '>=3.4.2'
-  handlebars@<4.7.9: '>=4.7.9'
-  js-yaml@<=4.1.1: '>=4.2.0'
-  minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
-  picomatch@<4.0.4: '>=4.0.4'
+  brace-expansion@<1.1.18: ^1.1.18
+  brace-expansion@>=2.0.0 <2.1.4: ^2.1.4
+  brace-expansion@>=3.0.0 <5.0.9: ^5.0.9


### PR DESCRIPTION
## Summary:

resolve https://github.com/OrcaBus/service-sequence-run-manager/issues/66.

This PR adds EventBridge emission for SequenceRunStateChange events when users create manual sequence-run states through the API. It also separates the SRM API event emitters for SRSSC and SRLLC, and refactors state transition behavior into a StateTransitionMixin.

## Changes:

- Add `emit_srsc_api_event` with SRSC schema validation and EventBridge failure handling.
- Split the previous SRM API emitter into `emit_srssc_api_event` and `emit_srllc_api_event`.
- Add `map_sequence_run_new_state_to_srsc`(sequence, state) to construct SRSC details from existing sequence metadata and the newly created state.
- Update `StateViewSet `so state creation, sequence status sync, SRSC construction, and SRSC emission happen in one transaction.
- Return 502 and rollback the new state when SRSC publication fails.
- Add `StateTransitionMixin` for transition rules, validation, and SRSC-emitting state creation.
- Update `add_samplesheet` action to call SRSSC and SRLLC emitters separately.
- Add/extend tests for SRSC EventBridge emission, publish failures, rollback behavior, and separated SRSSC/SRLLC emitters.