### PR TITLE
fix comment list with active record only

### DIFF
--- a/app/sequence_run_manager/models/comment.py
+++ b/app/sequence_run_manager/models/comment.py
@@ -10,7 +10,9 @@ class TargetType(models.TextChoices):
 
 
 class CommentManager(OrcaBusBaseManager):
-    pass
+    def active(self):
+        """Return comments that have not been soft-deleted."""
+        return self.filter(is_deleted=False)
 
 
 class Comment(OrcaBusBaseModel):

--- a/app/sequence_run_manager/tests/test_viewsets.py
+++ b/app/sequence_run_manager/tests/test_viewsets.py
@@ -302,6 +302,29 @@ class SequenceViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, 200, "Ok status response is expected")
         self.assertEqual(len(response.data), 2, "Two states are expected")
 
+    def test_get_sequence_comments_excludes_soft_deleted_comments(self):
+        instrument_run_id = "190101_A01052_0001_BH5LY7ACGT"
+        sequence = Sequence.objects.get(instrument_run_id=instrument_run_id)
+        active_comment = Comment.objects.get(
+            target_id=sequence.orcabus_id, target_type=TargetType.SEQUENCE
+        )
+        deleted_comment = Comment.objects.create(
+            target_id=sequence.orcabus_id,
+            target_type=TargetType.SEQUENCE,
+            comment="Deleted comment",
+            created_by="TestUser",
+            is_deleted=True,
+        )
+
+        response = self.client.get(
+            f"{self.sequence_endpoint}/{instrument_run_id}/comments/"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        returned_ids = {comment["orcabus_id"] for comment in response.data}
+        self.assertIn(str(active_comment.orcabus_id), returned_ids)
+        self.assertNotIn(str(deleted_comment.orcabus_id), returned_ids)
+
     # def test_add_sequence_run_comment(self):
     #     """
     #     python manage.py test sequence_run_manager.tests.test_viewsets.SequenceViewSetTestCase.test_add_sequence_comment

--- a/app/sequence_run_manager/viewsets/comment.py
+++ b/app/sequence_run_manager/viewsets/comment.py
@@ -51,9 +51,7 @@ class CommentViewSet(
     http_method_names = ["get", "post", "patch", "delete", "head", "options"]
 
     def get_queryset(self):
-        return Comment.objects.filter(
-            target_id=self.kwargs["orcabus_id"], is_deleted=False
-        )
+        return Comment.objects.active().filter(target_id=self.kwargs["orcabus_id"])
 
     def perform_create(self, serializer):
         serializer.save(target_id=self.kwargs["orcabus_id"])

--- a/app/sequence_run_manager/viewsets/sequence.py
+++ b/app/sequence_run_manager/viewsets/sequence.py
@@ -102,8 +102,9 @@ class SequenceViewSet(GenericViewSet):
         sample_sheets_orcabus_ids = SampleSheet.objects.filter(
             sequence__in=sequences_orcabus_ids
         ).values_list("orcabus_id", flat=True)
-        comments = Comment.objects.filter(target_id__in=sequences_orcabus_ids).union(
-            Comment.objects.filter(target_id__in=sample_sheets_orcabus_ids)
+        comments = Comment.objects.active().filter(
+            Q(target_id__in=sequences_orcabus_ids)
+            | Q(target_id__in=sample_sheets_orcabus_ids)
         )
         serializer = CommentSerializer(comments, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -125,7 +126,7 @@ class SequenceViewSet(GenericViewSet):
         instrument_run_id = kwargs.get("instrument_run_id")
         sequences = Sequence.objects.filter(instrument_run_id=instrument_run_id)
         sample_sheets = SampleSheet.objects.filter(sequence__in=sequences)
-        comments = Comment.objects.filter(
+        comments = Comment.objects.active().filter(
             target_id__in=sample_sheets.values_list("orcabus_id", flat=True)
         )
         for sample_sheet in sample_sheets:


### PR DESCRIPTION
## Summary

Fix soft-deleted comments appearing in:

`GET /api/v1/sequence/{instrument_run_id}/comments/`

## Root cause

This endpoint is handled by `SequenceViewSet.comments_by_instrument_run_id`, not `CommentViewSet.get_queryset`.

Although `CommentViewSet` already excluded comments where `is_deleted=True`, the sequence-level comment query did not apply the same filter.

## Changes

- Added `Comment.objects.active()` to centralize the active-comment filter.
- Updated sequence-level comment aggregation to exclude soft-deleted comments.
- Updated sample-sheet comment aggregation for consistent soft-delete behavior.
- Reused the active-comment query in `CommentViewSet`.
- Added a regression test for the reported endpoint.
